### PR TITLE
ci: add publish action for PyPI release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish asyncmcp to PyPI
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  pypi-publish:
+    name: Upload to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # For PyPI's trusted publishing
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@v6
+
+      - name: Build
+        run: uv build
+
+      - name: Publish to PyPi
+        run: uv publish -v dist/*


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for publishing the `asyncmcp` package to PyPI. The workflow is triggered on release events and supports manual dispatch.

### Workflow Addition:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R1-R26): Added a new workflow named "Publish asyncmcp to PyPI," which includes steps for checking out the repository, installing dependencies, building the package, and publishing it to PyPI using trusted publishing permissions.