### PR TITLE
fix: switch to dynamic versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "asyncmcp"
-version = "0.1.2"
+dynamic = ["version"]
 description = "Async MCP Transport layer for queue and async based systems"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"
@@ -76,6 +76,7 @@ source = "uv-dynamic-versioning"
 vcs = "git"
 style = "pep440"
 bump = true
+fallback-version = "0.0.0"
 
 [project.urls]
 Homepage = "https://github.com/bh-rat/asyncmcp"

--- a/uv.lock
+++ b/uv.lock
@@ -37,7 +37,6 @@ wheels = [
 
 [[package]]
 name = "asyncmcp"
-version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
@@ -95,7 +94,7 @@ requires-dist = [
     { name = "rich", marker = "extra == 'rich'", specifier = ">=13.9.4" },
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.12.4" },
 ]
-provides-extras = ["rich", "cli", "aws", "dev"]
+provides-extras = ["aws", "cli", "dev", "rich"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
This pull request updates the `pyproject.toml` file to improve version management by switching to dynamic versioning and adding a fallback version.

Version management improvements:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Changed the `version` field to `dynamic` to enable dynamic versioning.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R79): Added a `fallback-version` field under `source = "uv-dynamic-versioning"` to specify a default version ("0.0.0") in case dynamic versioning fails.