### PR TITLE
fix: update doc and fix client id

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ The whole idea of an **MCP server with async transport layer** is that it doesn'
 - Server : Transport layer that listens to a queue for MCP requests and writes the responses to a topic
 - Client : Transport layer that writes requests to a topic and listens to a queue for responses
 
+### Transport layer : sqs
+
+- Server : Transport layer that listens to a queue for MCP requests and writes the responses to another queue
+- Client : Transport layer that writes requests to a queue and listens to another queue for responses
+
 ## Installation and Usage
 
 ```bash

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,13 +34,21 @@ uv run setup.py
 ### 3. Start the MCP Transport Server (Terminal 1)
 
 ```bash
+# Using SNS-SQS transport (default)
 uv run website_server.py
+
+# Using SQS-only transport
+uv run website_server.py --transport sqs
 ```
 
 ### 4. Start the CLI (Terminal 2) 
 
 ```bash
+# Using SNS-SQS transport (default)
 uv run website_client.py
+
+# Using SQS-only transport
+uv run website_client.py --transport sqs
 ```
 
 ### 5. Try the workflow

--- a/src/asyncmcp/__init__.py
+++ b/src/asyncmcp/__init__.py
@@ -11,10 +11,16 @@ __version__ = "0.1.0"
 from asyncmcp.sns_sqs.utils import SnsSqsTransportConfig
 from asyncmcp.sns_sqs.client import sns_sqs_client
 from asyncmcp.sns_sqs.server import sns_sqs_server
+from asyncmcp.sqs.utils import SqsTransportConfig
+from asyncmcp.sqs.client import sqs_client
+from asyncmcp.sqs.server import sqs_server
 
 __all__ = [
     "SnsSqsTransportConfig",
-    "sns_sqs_client",
+    "sns_sqs_client", 
     "sns_sqs_server",
+    "SqsTransportConfig",
+    "sqs_client",
+    "sqs_server",
     "__version__",
 ]

--- a/src/asyncmcp/sqs/client.py
+++ b/src/asyncmcp/sqs/client.py
@@ -50,7 +50,7 @@ async def sqs_client(
     tuple[MemoryObjectReceiveStream[SessionMessage | Exception], MemoryObjectSendStream[SessionMessage]],
     None,
 ]:
-    client_id = str(uuid.uuid4())
+    client_id = config.client_id or str(uuid.uuid4())
 
     read_stream_writer: MemoryObjectSendStream[SessionMessage | Exception]
     read_stream: MemoryObjectReceiveStream[SessionMessage | Exception]


### PR DESCRIPTION
This pull request introduces support for a new SQS-only transport layer in the MCP framework, alongside the existing SNS-SQS transport. Key changes include updates to documentation, configuration, and code to integrate the new transport option.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R34-R38): Added details about the SQS-only transport layer, including how the server and client interact using queues for requests and responses.
* [`examples/README.md`](diffhunk://#diff-49aaa2819e35a856818ecec8c9fa7e1c79ad028d3f44bd749736353cfb51bac9R37-R51): Updated example commands to demonstrate usage of both the default SNS-SQS transport and the new SQS-only transport.

### Code Enhancements:
* [`src/asyncmcp/__init__.py`](diffhunk://#diff-a7ab423bcf13da4896e9914ce1044e7a8ffbe4e9a0e9a0efc09e33d3e1527da4R14-R24): Added imports and `__all__` entries for SQS transport configurations, client, and server, enabling integration with the SQS-only transport layer.
* [`src/asyncmcp/sqs/client.py`](diffhunk://#diff-e942c23fc340e82c1503647029e801526dd1c4a59105110d0a77211156f2eec1L53-R53): Modified the SQS client to use a configurable `client_id` if provided, falling back to a generated UUID otherwise.