### PR TITLE
feat: add proxy for running asyncmcp servers as shttp servers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,128 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+AsyncMCP provides async transport layer implementations for MCP (Model Context Protocol), supporting AWS SQS, SNS+SQS, and webhook-based transports beyond the standard stdio and HTTP transports. The library enables MCP servers to handle requests asynchronously through queues and webhooks rather than requiring immediate responses.
+
+## Development Commands
+
+### Testing
+```bash
+# Run all tests
+uv run pytest
+
+# Run specific test module
+uv run pytest tests/sqs/test_integration.py
+
+# Run tests with specific markers
+uv run pytest -m integration
+uv run pytest -m unit
+```
+
+### Code Quality
+```bash
+# Type checking with pyright
+uv run pyright
+
+# Linting with ruff
+uv run ruff check
+
+# Format code with ruff
+uv run ruff format
+```
+
+### Local Development Setup
+```bash
+# Install dependencies
+uv sync
+
+# Setup LocalStack for testing (required for SQS/SNS examples)
+localstack start
+
+# Setup LocalStack resources for examples
+uv run examples/setup.py
+```
+
+### Example Usage
+```bash
+# SNS-SQS transport example
+uv run examples/website_server.py  # Terminal 1
+uv run examples/website_client.py  # Terminal 2
+
+# SQS-only transport example  
+uv run examples/website_server.py --transport sqs
+uv run examples/website_client.py --transport sqs
+
+# Webhook transport example
+uv run examples/webhook_server.py --server-port 8000  # Terminal 1
+uv run examples/webhook_client.py --server-port 8000 --webhook-port 8001  # Terminal 2
+```
+
+## Architecture
+
+### Core Components
+
+- **Common Layer** (`src/asyncmcp/common/`): Base protocols and server transport implementation
+  - `protocols.py`: Defines `ServerTransportProtocol` interface 
+  - `server.py`: Base `ServerTransport` class with stream management
+  - `outgoing_event.py`: Event model for message forwarding
+  - `client_state.py`: Client session state management
+
+- **Transport Implementations**: Three transport mechanisms in separate modules
+  - **SQS** (`src/asyncmcp/sqs/`): Queue-to-queue communication
+  - **SNS+SQS** (`src/asyncmcp/sns_sqs/`): Topic-based pub/sub with SQS queues
+  - **Webhook** (`src/asyncmcp/webhook/`): HTTP POST requests with webhook responses
+
+### Session Management Pattern
+
+Each transport type follows a consistent session manager pattern:
+- `*Manager` classes handle multiple client sessions
+- Individual transport instances handle single client sessions  
+- Session managers route messages between central queues/topics and per-session transports
+- Managers support dynamic session creation based on incoming requests
+
+### Key Architectural Patterns
+
+1. **Async Context Managers**: All transports use `async with` for resource management
+2. **Memory Streams**: Internal communication uses anyio memory object streams
+3. **Protocol Compliance**: All transports implement `ServerTransportProtocol`
+4. **Session Isolation**: Each client gets isolated transport instance with unique session ID
+
+### Transport-Specific Details
+
+**SQS Transport**: 
+- Server listens on request queue, sends responses to client-specific response queues
+- Client provides response queue URL in initialize request
+- Uses SQS message attributes for metadata
+
+**SNS+SQS Transport**:
+- Server listens on SQS queue, publishes responses to SNS topic
+- Clients subscribe to topic with individual SQS queues
+- Topic-based message routing with filtering
+
+**Webhook Transport**:
+- Client sends HTTP POST to server endpoints
+- Server responds via HTTP POST to client webhook URLs
+- Client provides webhook URL in initialize request `_meta` field
+
+## Testing Strategy
+
+Tests are organized by transport type with consistent structure:
+- `conftest.py`: Transport-specific fixtures and configuration
+- `shared_fixtures.py`: Common test fixtures and utilities
+- `test_client_transport.py`: Client-side transport unit tests
+- `test_server_transport.py`: Server-side transport unit tests  
+- `test_integration.py`: End-to-end integration tests
+
+LocalStack is required for SQS/SNS testing. Webhook tests use httpx mock clients.
+
+## Configuration
+
+Transport configurations are defined in `utils.py` files within each transport module:
+- `SqsTransportConfig`: SQS queue URLs and message attributes
+- `SnsSqsServerConfig`/`SnsSqsClientConfig`: Topic ARNs and queue URLs
+- `WebhookTransportConfig`: HTTP client settings and timeouts
+
+All configs support customizable message attributes and transport-specific parameters.

--- a/examples/proxy_client_interactive.py
+++ b/examples/proxy_client_interactive.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Interactive MCP client for testing the proxy server.
+
+This example provides an interactive client that connects to the proxy server
+using the standard MCP SSE transport. It demonstrates:
+1. Establishing an SSE connection with the proxy
+2. Initializing the MCP session
+3. Listing available tools
+4. Calling tools interactively
+5. Handling responses and errors
+
+Usage:
+    # Connect to local proxy server
+    python proxy_client.py
+    
+    # Connect to proxy on different host/port
+    python proxy_client.py --url http://localhost:9090/mcp
+    
+    # Connect with authentication
+    python proxy_client.py --auth-token "secret-token"
+"""
+
+import asyncio
+import json
+import sys
+from typing import Optional
+
+import click
+from mcp.client.session import ClientSession
+from mcp.client.sse import sse_client
+from mcp.types import Tool
+
+
+class InteractiveProxyClient:
+    """Interactive client for testing MCP proxy servers."""
+    
+    def __init__(self, proxy_url: str, auth_token: Optional[str] = None):
+        self.proxy_url = proxy_url
+        self.auth_token = auth_token
+        self.session: Optional[ClientSession] = None
+        self.tools: list[Tool] = []
+        
+    async def connect(self):
+        """Connect to the proxy server and initialize session."""
+        print(f"🔌 Connecting to proxy at {self.proxy_url}...")
+        
+        headers = {}
+        if self.auth_token:
+            headers["Authorization"] = f"Bearer {self.auth_token}"
+        
+        try:
+            # Create SSE connection using context manager
+            self.sse_context = sse_client(self.proxy_url, headers=headers)
+            self.read, self.write = await self.sse_context.__aenter__()
+            
+            print("✅ Connected to proxy server (SSE established)")
+            
+            # Create MCP session
+            self.session = ClientSession(self.read, self.write)
+            await self.session.__aenter__()
+            
+            print("✅ MCP session created")
+            
+            # Initialize session
+            print("\n📋 Initializing MCP session...")
+            result = await self.session.initialize()
+            
+            print(f"✅ Session initialized!")
+            print(f"   Server: {result.serverInfo.name} v{result.serverInfo.version}")
+            print(f"   Protocol: {result.protocolVersion}")
+            if result.capabilities:
+                print(f"   Capabilities: {list(result.capabilities.model_dump(exclude_none=True).keys())}")
+                
+        except Exception as e:
+            print(f"❌ Connection failed: {type(e).__name__}: {e}")
+            # If it's an ExceptionGroup, show the underlying errors
+            if hasattr(e, '__exceptions__'):
+                for i, sub_e in enumerate(e.__exceptions__):
+                    print(f"   Sub-error {i+1}: {type(sub_e).__name__}: {sub_e}")
+            raise
+            
+    async def list_tools(self):
+        """List available tools from the server."""
+        print("\n🔧 Fetching available tools...")
+        result = await self.session.list_tools()
+        self.tools = result.tools
+        
+        if not self.tools:
+            print("❌ No tools available")
+            return
+            
+        print(f"✅ Found {len(self.tools)} tool(s):")
+        for i, tool in enumerate(self.tools):
+            print(f"\n{i+1}. {tool.name}")
+            if tool.description:
+                print(f"   Description: {tool.description}")
+            if tool.inputSchema:
+                schema = tool.inputSchema
+                if hasattr(schema, 'properties'):
+                    props = schema.properties or {}
+                    if props:
+                        print("   Parameters:")
+                        for name, prop in props.items():
+                            required = name in (schema.required or [])
+                            req_str = " (required)" if required else " (optional)"
+                            desc = prop.get('description', 'No description')
+                            print(f"     - {name}: {desc}{req_str}")
+                            
+    async def call_tool(self, tool_name: str, arguments: dict):
+        """Call a tool with the given arguments."""
+        print(f"\n🚀 Calling tool '{tool_name}'...")
+        print(f"   Arguments: {json.dumps(arguments, indent=2)}")
+        
+        try:
+            result = await self.session.call_tool(tool_name, arguments)
+            
+            print(f"✅ Tool executed successfully!")
+            print(f"   Result has {len(result.content)} content block(s)")
+            
+            for i, content in enumerate(result.content):
+                print(f"\n   Content {i+1}:")
+                if hasattr(content, 'text'):
+                    # TextContent
+                    text = content.text
+                    if len(text) > 200:
+                        print(f"     Text: {text[:200]}...")
+                        print(f"     (Total length: {len(text)} characters)")
+                    else:
+                        print(f"     Text: {text}")
+                elif hasattr(content, 'data'):
+                    # ImageContent or other binary content
+                    print(f"     Type: {content.type}")
+                    print(f"     Data size: {len(content.data)} bytes")
+                else:
+                    print(f"     Type: {content.type}")
+                    print(f"     Content: {content}")
+                    
+        except Exception as e:
+            print(f"❌ Error calling tool: {type(e).__name__}: {e}")
+            
+    async def interactive_loop(self):
+        """Run the interactive command loop."""
+        print("\n" + "="*60)
+        print("Interactive MCP Proxy Client")
+        print("="*60)
+        print("\nCommands:")
+        print("  list    - List available tools")
+        print("  call    - Call a tool")
+        print("  help    - Show this help")
+        print("  quit    - Exit the client")
+        print()
+        
+        while True:
+            try:
+                command = input("\n> ").strip().lower()
+                
+                if command == "quit" or command == "exit":
+                    print("👋 Goodbye!")
+                    break
+                    
+                elif command == "help":
+                    print("\nCommands:")
+                    print("  list    - List available tools")
+                    print("  call    - Call a tool")
+                    print("  help    - Show this help")
+                    print("  quit    - Exit the client")
+                    
+                elif command == "list":
+                    await self.list_tools()
+                    
+                elif command == "call":
+                    if not self.tools:
+                        print("❌ No tools available. Run 'list' first.")
+                        continue
+                        
+                    # Show tools
+                    print("\nAvailable tools:")
+                    for i, tool in enumerate(self.tools):
+                        print(f"  {i+1}. {tool.name}")
+                        
+                    # Get tool selection
+                    try:
+                        choice = input("\nSelect tool (number or name): ").strip()
+                        
+                        # Try to parse as number
+                        tool = None
+                        try:
+                            idx = int(choice) - 1
+                            if 0 <= idx < len(self.tools):
+                                tool = self.tools[idx]
+                        except ValueError:
+                            # Try to match by name
+                            for t in self.tools:
+                                if t.name.lower() == choice.lower():
+                                    tool = t
+                                    break
+                                    
+                        if not tool:
+                            print("❌ Invalid tool selection")
+                            continue
+                            
+                        # Get arguments
+                        print(f"\nCalling tool: {tool.name}")
+                        if tool.inputSchema and hasattr(tool.inputSchema, 'properties'):
+                            props = tool.inputSchema.properties or {}
+                            required = tool.inputSchema.required or []
+                            
+                            arguments = {}
+                            for name, prop in props.items():
+                                is_required = name in required
+                                desc = prop.get('description', 'No description')
+                                prompt = f"{name} ({desc})"
+                                if is_required:
+                                    prompt += " [required]"
+                                else:
+                                    prompt += " [optional]"
+                                prompt += ": "
+                                
+                                value = input(prompt).strip()
+                                if value or is_required:
+                                    # Try to parse as JSON
+                                    try:
+                                        arguments[name] = json.loads(value)
+                                    except:
+                                        # Use as string
+                                        arguments[name] = value
+                        else:
+                            # No schema, get raw JSON
+                            args_str = input("Arguments (JSON): ").strip()
+                            if args_str:
+                                arguments = json.loads(args_str)
+                            else:
+                                arguments = {}
+                                
+                        # Call the tool
+                        await self.call_tool(tool.name, arguments)
+                        
+                    except (KeyboardInterrupt, EOFError):
+                        print("\n❌ Cancelled")
+                        continue
+                    except Exception as e:
+                        print(f"❌ Error: {e}")
+                        continue
+                        
+                else:
+                    print(f"❌ Unknown command: {command}")
+                    print("   Type 'help' for available commands")
+                    
+            except (KeyboardInterrupt, EOFError):
+                print("\n👋 Goodbye!")
+                break
+            except Exception as e:
+                print(f"❌ Error: {e}")
+                
+    async def disconnect(self):
+        """Disconnect from the proxy server."""
+        if self.session:
+            await self.session.__aexit__(None, None, None)
+        if hasattr(self, 'sse_context'):
+            await self.sse_context.__aexit__(None, None, None)
+            
+    async def run(self):
+        """Run the interactive client."""
+        try:
+            await self.connect()
+            await self.interactive_loop()
+        finally:
+            await self.disconnect()
+
+
+@click.command()
+@click.option(
+    "--url",
+    default="http://localhost:8080/mcp",
+    help="Proxy server URL",
+)
+@click.option(
+    "--auth-token",
+    help="Authentication token for the proxy",
+)
+def main(url: str, auth_token: Optional[str]):
+    """Interactive MCP client for testing proxy servers."""
+    client = InteractiveProxyClient(url, auth_token)
+    
+    try:
+        asyncio.run(client.run())
+    except KeyboardInterrupt:
+        print("\n👋 Goodbye!")
+        sys.exit(0)
+    except Exception as e:
+        print(f"❌ Fatal error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/proxy_client_interactive.py
+++ b/examples/proxy_client_interactive.py
@@ -12,10 +12,10 @@ using the standard MCP SSE transport. It demonstrates:
 Usage:
     # Connect to local proxy server
     python proxy_client.py
-    
+
     # Connect to proxy on different host/port
     python proxy_client.py --url http://localhost:9090/mcp
-    
+
     # Connect with authentication
     python proxy_client.py --auth-token "secret-token"
 """
@@ -33,93 +33,93 @@ from mcp.types import Tool
 
 class InteractiveProxyClient:
     """Interactive client for testing MCP proxy servers."""
-    
+
     def __init__(self, proxy_url: str, auth_token: Optional[str] = None):
         self.proxy_url = proxy_url
         self.auth_token = auth_token
         self.session: Optional[ClientSession] = None
         self.tools: list[Tool] = []
-        
+
     async def connect(self):
         """Connect to the proxy server and initialize session."""
         print(f"🔌 Connecting to proxy at {self.proxy_url}...")
-        
+
         headers = {}
         if self.auth_token:
             headers["Authorization"] = f"Bearer {self.auth_token}"
-        
+
         try:
             # Create SSE connection using context manager
             self.sse_context = sse_client(self.proxy_url, headers=headers)
             self.read, self.write = await self.sse_context.__aenter__()
-            
+
             print("✅ Connected to proxy server (SSE established)")
-            
+
             # Create MCP session
             self.session = ClientSession(self.read, self.write)
             await self.session.__aenter__()
-            
+
             print("✅ MCP session created")
-            
+
             # Initialize session
             print("\n📋 Initializing MCP session...")
             result = await self.session.initialize()
-            
+
             print(f"✅ Session initialized!")
             print(f"   Server: {result.serverInfo.name} v{result.serverInfo.version}")
             print(f"   Protocol: {result.protocolVersion}")
             if result.capabilities:
                 print(f"   Capabilities: {list(result.capabilities.model_dump(exclude_none=True).keys())}")
-                
+
         except Exception as e:
             print(f"❌ Connection failed: {type(e).__name__}: {e}")
             # If it's an ExceptionGroup, show the underlying errors
-            if hasattr(e, '__exceptions__'):
+            if hasattr(e, "__exceptions__"):
                 for i, sub_e in enumerate(e.__exceptions__):
-                    print(f"   Sub-error {i+1}: {type(sub_e).__name__}: {sub_e}")
+                    print(f"   Sub-error {i + 1}: {type(sub_e).__name__}: {sub_e}")
             raise
-            
+
     async def list_tools(self):
         """List available tools from the server."""
         print("\n🔧 Fetching available tools...")
         result = await self.session.list_tools()
         self.tools = result.tools
-        
+
         if not self.tools:
             print("❌ No tools available")
             return
-            
+
         print(f"✅ Found {len(self.tools)} tool(s):")
         for i, tool in enumerate(self.tools):
-            print(f"\n{i+1}. {tool.name}")
+            print(f"\n{i + 1}. {tool.name}")
             if tool.description:
                 print(f"   Description: {tool.description}")
             if tool.inputSchema:
                 schema = tool.inputSchema
-                if hasattr(schema, 'properties'):
+                if hasattr(schema, "properties"):
                     props = schema.properties or {}
                     if props:
                         print("   Parameters:")
                         for name, prop in props.items():
                             required = name in (schema.required or [])
                             req_str = " (required)" if required else " (optional)"
-                            desc = prop.get('description', 'No description')
+                            desc = prop.get("description", "No description")
                             print(f"     - {name}: {desc}{req_str}")
-                            
+
     async def call_tool(self, tool_name: str, arguments: dict):
         """Call a tool with the given arguments."""
         print(f"\n🚀 Calling tool '{tool_name}'...")
         print(f"   Arguments: {json.dumps(arguments, indent=2)}")
-        
+
         try:
             result = await self.session.call_tool(tool_name, arguments)
-            
+
             print(f"✅ Tool executed successfully!")
             print(f"   Result has {len(result.content)} content block(s)")
-            
+
             for i, content in enumerate(result.content):
-                print(f"\n   Content {i+1}:")
-                if hasattr(content, 'text'):
+                print(f"\n   Content {i + 1}:")
+                if hasattr(content, "text"):
                     # TextContent
                     text = content.text
                     if len(text) > 200:
@@ -127,61 +127,61 @@ class InteractiveProxyClient:
                         print(f"     (Total length: {len(text)} characters)")
                     else:
                         print(f"     Text: {text}")
-                elif hasattr(content, 'data'):
+                elif hasattr(content, "data"):
                     # ImageContent or other binary content
                     print(f"     Type: {content.type}")
                     print(f"     Data size: {len(content.data)} bytes")
                 else:
                     print(f"     Type: {content.type}")
                     print(f"     Content: {content}")
-                    
+
         except Exception as e:
             print(f"❌ Error calling tool: {type(e).__name__}: {e}")
-            
+
     async def interactive_loop(self):
         """Run the interactive command loop."""
-        print("\n" + "="*60)
+        print("\n" + "=" * 60)
         print("Interactive MCP Proxy Client")
-        print("="*60)
+        print("=" * 60)
         print("\nCommands:")
         print("  list    - List available tools")
         print("  call    - Call a tool")
         print("  help    - Show this help")
         print("  quit    - Exit the client")
         print()
-        
+
         while True:
             try:
                 command = input("\n> ").strip().lower()
-                
+
                 if command == "quit" or command == "exit":
                     print("👋 Goodbye!")
                     break
-                    
+
                 elif command == "help":
                     print("\nCommands:")
                     print("  list    - List available tools")
                     print("  call    - Call a tool")
                     print("  help    - Show this help")
                     print("  quit    - Exit the client")
-                    
+
                 elif command == "list":
                     await self.list_tools()
-                    
+
                 elif command == "call":
                     if not self.tools:
                         print("❌ No tools available. Run 'list' first.")
                         continue
-                        
+
                     # Show tools
                     print("\nAvailable tools:")
                     for i, tool in enumerate(self.tools):
-                        print(f"  {i+1}. {tool.name}")
-                        
+                        print(f"  {i + 1}. {tool.name}")
+
                     # Get tool selection
                     try:
                         choice = input("\nSelect tool (number or name): ").strip()
-                        
+
                         # Try to parse as number
                         tool = None
                         try:
@@ -194,28 +194,28 @@ class InteractiveProxyClient:
                                 if t.name.lower() == choice.lower():
                                     tool = t
                                     break
-                                    
+
                         if not tool:
                             print("❌ Invalid tool selection")
                             continue
-                            
+
                         # Get arguments
                         print(f"\nCalling tool: {tool.name}")
-                        if tool.inputSchema and hasattr(tool.inputSchema, 'properties'):
+                        if tool.inputSchema and hasattr(tool.inputSchema, "properties"):
                             props = tool.inputSchema.properties or {}
                             required = tool.inputSchema.required or []
-                            
+
                             arguments = {}
                             for name, prop in props.items():
                                 is_required = name in required
-                                desc = prop.get('description', 'No description')
+                                desc = prop.get("description", "No description")
                                 prompt = f"{name} ({desc})"
                                 if is_required:
                                     prompt += " [required]"
                                 else:
                                     prompt += " [optional]"
                                 prompt += ": "
-                                
+
                                 value = input(prompt).strip()
                                 if value or is_required:
                                     # Try to parse as JSON
@@ -231,34 +231,34 @@ class InteractiveProxyClient:
                                 arguments = json.loads(args_str)
                             else:
                                 arguments = {}
-                                
+
                         # Call the tool
                         await self.call_tool(tool.name, arguments)
-                        
+
                     except (KeyboardInterrupt, EOFError):
                         print("\n❌ Cancelled")
                         continue
                     except Exception as e:
                         print(f"❌ Error: {e}")
                         continue
-                        
+
                 else:
                     print(f"❌ Unknown command: {command}")
                     print("   Type 'help' for available commands")
-                    
+
             except (KeyboardInterrupt, EOFError):
                 print("\n👋 Goodbye!")
                 break
             except Exception as e:
                 print(f"❌ Error: {e}")
-                
+
     async def disconnect(self):
         """Disconnect from the proxy server."""
         if self.session:
             await self.session.__aexit__(None, None, None)
-        if hasattr(self, 'sse_context'):
+        if hasattr(self, "sse_context"):
             await self.sse_context.__aexit__(None, None, None)
-            
+
     async def run(self):
         """Run the interactive client."""
         try:
@@ -281,7 +281,7 @@ class InteractiveProxyClient:
 def main(url: str, auth_token: Optional[str]):
     """Interactive MCP client for testing proxy servers."""
     client = InteractiveProxyClient(url, auth_token)
-    
+
     try:
         asyncio.run(client.run())
     except KeyboardInterrupt:

--- a/examples/proxy_client_mcp.py
+++ b/examples/proxy_client_mcp.py
@@ -20,102 +20,102 @@ async def run_client(proxy_url: str, auth_token: Optional[str] = None):
     headers = {}
     if auth_token:
         headers["Authorization"] = f"Bearer {auth_token}"
-    
+
     print(f"🔌 Connecting to proxy at {proxy_url}...")
-    
+
     # Use MCP SDK's sse_client
     async with sse_client(proxy_url, headers=headers) as (read, write):
         print("✅ SSE connection established")
-        
+
         # Create MCP session
         async with ClientSession(read, write) as session:
             print("✅ Client session created")
-            
+
             # Initialize the session
             print("\n📋 Initializing MCP session...")
             result = await session.initialize()
-            
+
             print(f"✅ Session initialized!")
             print(f"   Server: {result.serverInfo.name} v{result.serverInfo.version}")
             print(f"   Protocol: {result.protocolVersion}")
-            
+
             # List tools
             print("\n🔧 Listing available tools...")
             tools_result = await session.list_tools()
-            
+
             if not tools_result.tools:
                 print("❌ No tools available")
                 return
-                
+
             print(f"✅ Found {len(tools_result.tools)} tool(s):")
             for tool in tools_result.tools:
                 print(f"   • {tool.name}: {tool.description or 'No description'}")
-            
+
             # Interactive loop
-            print("\n" + "="*60)
+            print("\n" + "=" * 60)
             print("Interactive Mode - Commands:")
             print("  call <tool_name> <arg1>=<value1> <arg2>=<value2> ...")
             print("  list - List tools again")
             print("  quit - Exit")
-            print("="*60)
-            
+            print("=" * 60)
+
             while True:
                 try:
                     command = input("\n> ").strip()
-                    
+
                     if command.lower() in ["quit", "exit"]:
                         print("👋 Goodbye!")
                         break
-                        
+
                     elif command.lower() == "list":
                         tools_result = await session.list_tools()
                         print(f"Available tools:")
                         for tool in tools_result.tools:
                             print(f"   • {tool.name}: {tool.description or 'No description'}")
-                            
+
                     elif command.lower().startswith("call "):
                         # Parse command
                         parts = command[5:].split()
                         if not parts:
                             print("❌ Usage: call <tool_name> <arg>=<value> ...")
                             continue
-                            
+
                         tool_name = parts[0]
                         arguments = {}
-                        
+
                         # Parse arguments
                         for part in parts[1:]:
                             if "=" in part:
                                 key, value = part.split("=", 1)
                                 arguments[key] = value
-                        
+
                         # Call tool
                         print(f"\n🚀 Calling tool '{tool_name}'...")
                         if arguments:
                             print(f"   Arguments: {arguments}")
-                            
+
                         try:
                             result = await session.call_tool(tool_name, arguments)
-                            
+
                             print(f"✅ Tool executed successfully!")
                             for i, content in enumerate(result.content):
-                                if hasattr(content, 'text'):
+                                if hasattr(content, "text"):
                                     text = content.text
                                     if len(text) > 200:
-                                        print(f"\n📄 Result {i+1}: {text[:200]}...")
+                                        print(f"\n📄 Result {i + 1}: {text[:200]}...")
                                         print(f"   (Total: {len(text)} characters)")
                                     else:
-                                        print(f"\n📄 Result {i+1}: {text}")
+                                        print(f"\n📄 Result {i + 1}: {text}")
                                 else:
-                                    print(f"\n📦 Result {i+1}: {content}")
-                                    
+                                    print(f"\n📦 Result {i + 1}: {content}")
+
                         except Exception as e:
                             print(f"❌ Error: {e}")
-                            
+
                     else:
                         print(f"❌ Unknown command: {command}")
                         print("   Type 'help' for available commands")
-                        
+
                 except (KeyboardInterrupt, EOFError):
                     print("\n👋 Goodbye!")
                     break

--- a/examples/proxy_client_mcp.py
+++ b/examples/proxy_client_mcp.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""MCP client for testing the proxy server using the MCP SDK.
+
+This example shows how to properly connect to the proxy server
+using the MCP SDK's sse_client.
+"""
+
+import asyncio
+import sys
+from typing import Optional
+
+import click
+from mcp.client.session import ClientSession
+from mcp.client.sse import sse_client
+import mcp.types as types
+
+
+async def run_client(proxy_url: str, auth_token: Optional[str] = None):
+    """Connect to proxy and run interactive session."""
+    headers = {}
+    if auth_token:
+        headers["Authorization"] = f"Bearer {auth_token}"
+    
+    print(f"🔌 Connecting to proxy at {proxy_url}...")
+    
+    # Use MCP SDK's sse_client
+    async with sse_client(proxy_url, headers=headers) as (read, write):
+        print("✅ SSE connection established")
+        
+        # Create MCP session
+        async with ClientSession(read, write) as session:
+            print("✅ Client session created")
+            
+            # Initialize the session
+            print("\n📋 Initializing MCP session...")
+            result = await session.initialize()
+            
+            print(f"✅ Session initialized!")
+            print(f"   Server: {result.serverInfo.name} v{result.serverInfo.version}")
+            print(f"   Protocol: {result.protocolVersion}")
+            
+            # List tools
+            print("\n🔧 Listing available tools...")
+            tools_result = await session.list_tools()
+            
+            if not tools_result.tools:
+                print("❌ No tools available")
+                return
+                
+            print(f"✅ Found {len(tools_result.tools)} tool(s):")
+            for tool in tools_result.tools:
+                print(f"   • {tool.name}: {tool.description or 'No description'}")
+            
+            # Interactive loop
+            print("\n" + "="*60)
+            print("Interactive Mode - Commands:")
+            print("  call <tool_name> <arg1>=<value1> <arg2>=<value2> ...")
+            print("  list - List tools again")
+            print("  quit - Exit")
+            print("="*60)
+            
+            while True:
+                try:
+                    command = input("\n> ").strip()
+                    
+                    if command.lower() in ["quit", "exit"]:
+                        print("👋 Goodbye!")
+                        break
+                        
+                    elif command.lower() == "list":
+                        tools_result = await session.list_tools()
+                        print(f"Available tools:")
+                        for tool in tools_result.tools:
+                            print(f"   • {tool.name}: {tool.description or 'No description'}")
+                            
+                    elif command.lower().startswith("call "):
+                        # Parse command
+                        parts = command[5:].split()
+                        if not parts:
+                            print("❌ Usage: call <tool_name> <arg>=<value> ...")
+                            continue
+                            
+                        tool_name = parts[0]
+                        arguments = {}
+                        
+                        # Parse arguments
+                        for part in parts[1:]:
+                            if "=" in part:
+                                key, value = part.split("=", 1)
+                                arguments[key] = value
+                        
+                        # Call tool
+                        print(f"\n🚀 Calling tool '{tool_name}'...")
+                        if arguments:
+                            print(f"   Arguments: {arguments}")
+                            
+                        try:
+                            result = await session.call_tool(tool_name, arguments)
+                            
+                            print(f"✅ Tool executed successfully!")
+                            for i, content in enumerate(result.content):
+                                if hasattr(content, 'text'):
+                                    text = content.text
+                                    if len(text) > 200:
+                                        print(f"\n📄 Result {i+1}: {text[:200]}...")
+                                        print(f"   (Total: {len(text)} characters)")
+                                    else:
+                                        print(f"\n📄 Result {i+1}: {text}")
+                                else:
+                                    print(f"\n📦 Result {i+1}: {content}")
+                                    
+                        except Exception as e:
+                            print(f"❌ Error: {e}")
+                            
+                    else:
+                        print(f"❌ Unknown command: {command}")
+                        print("   Type 'help' for available commands")
+                        
+                except (KeyboardInterrupt, EOFError):
+                    print("\n👋 Goodbye!")
+                    break
+                except Exception as e:
+                    print(f"❌ Error: {e}")
+
+
+@click.command()
+@click.option(
+    "--url",
+    default="http://localhost:8080/mcp",
+    help="Proxy server URL",
+)
+@click.option(
+    "--auth-token",
+    help="Authentication token for the proxy",
+)
+def main(url: str, auth_token: Optional[str]):
+    """MCP client for testing proxy servers."""
+    try:
+        asyncio.run(run_client(url, auth_token))
+    except KeyboardInterrupt:
+        print("\n👋 Goodbye!")
+        sys.exit(0)
+    except Exception as e:
+        print(f"❌ Fatal error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/proxy_server.py
+++ b/examples/proxy_server.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Example proxy server that bridges StreamableHTTP to asyncmcp transports.
+
+This example demonstrates how to set up a proxy server that:
+1. Exposes a standard MCP StreamableHTTP endpoint
+2. Forwards requests to an asyncmcp backend (SQS, SNS+SQS, Webhook)
+3. Streams responses back to the client
+
+Usage:
+    # Start proxy with SQS backend
+    python proxy_server.py --backend sqs
+    
+    # Start proxy with SNS+SQS backend
+    python proxy_server.py --backend sns-sqs
+    
+    # Start proxy with authentication
+    python proxy_server.py --backend sqs --auth-token "secret-token"
+    
+    # Start proxy on custom port
+    python proxy_server.py --backend sqs --port 9090
+"""
+
+import asyncio
+import logging
+import os
+from typing import Optional
+
+import boto3
+import click
+
+from asyncmcp.proxy import ProxyConfig, ProxyServer, create_proxy_server
+from asyncmcp.sqs.utils import SqsClientConfig
+from asyncmcp.sns_sqs.utils import SnsSqsClientConfig
+from asyncmcp.webhook.utils import WebhookClientConfig
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)8s] %(name)s: %(message)s",
+)
+
+logger = logging.getLogger(__name__)
+
+# AWS LocalStack configuration
+AWS_CONFIG = {
+    "region_name": "us-east-1",
+    "endpoint_url": os.environ.get("AWS_ENDPOINT_URL", "http://localhost:4566"),
+    "aws_access_key_id": "test",
+    "aws_secret_access_key": "test",
+}
+
+# Default queue/topic ARNs for LocalStack
+DEFAULT_RESOURCES = {
+    "sqs_request_queue": "http://localhost:4566/000000000000/mcp-processor",
+    "sqs_response_queue": "http://localhost:4566/000000000000/mcp-consumer",
+    "sns_topic": "arn:aws:sns:us-east-1:000000000000:mcp-proxy-topic",
+    "webhook_server": "http://localhost:8001/mcp/request",
+}
+
+
+def create_sqs_backend_config() -> tuple[SqsClientConfig, dict]:
+    """Create SQS backend configuration."""
+    sqs_client = boto3.client("sqs", **AWS_CONFIG)
+    
+    config = SqsClientConfig(
+        read_queue_url=DEFAULT_RESOURCES["sqs_request_queue"],
+        response_queue_url=DEFAULT_RESOURCES["sqs_response_queue"],
+    )
+    
+    backend_clients = {"sqs_client": sqs_client}
+    
+    return config, backend_clients
+
+
+def create_sns_sqs_backend_config() -> tuple[SnsSqsClientConfig, dict]:
+    """Create SNS+SQS backend configuration."""
+    sqs_client = boto3.client("sqs", **AWS_CONFIG)
+    sns_client = boto3.client("sns", **AWS_CONFIG)
+    
+    config = SnsSqsClientConfig(
+        sns_topic_arn=DEFAULT_RESOURCES["sns_topic"],
+        sqs_queue_url=DEFAULT_RESOURCES["sqs_response_queue"],
+    )
+    
+    backend_clients = {
+        "sqs_client": sqs_client,
+        "sns_client": sns_client,
+    }
+    
+    return config, backend_clients
+
+
+def create_webhook_backend_config() -> tuple[WebhookClientConfig, dict]:
+    """Create Webhook backend configuration."""
+    config = WebhookClientConfig(
+        server_url=DEFAULT_RESOURCES["webhook_server"],
+    )
+    
+    backend_clients = {}
+    
+    return config, backend_clients
+
+
+@click.command()
+@click.option(
+    "--backend",
+    type=click.Choice(["sqs", "sns-sqs", "webhook"], case_sensitive=False),
+    default="sqs",
+    help="Backend transport type",
+)
+@click.option(
+    "--host",
+    default="127.0.0.1",
+    help="Host to bind the proxy server to",
+)
+@click.option(
+    "--port",
+    type=int,
+    default=8080,
+    help="Port to bind the proxy server to",
+)
+@click.option(
+    "--server-path",
+    default="/mcp",
+    help="HTTP path for the MCP endpoint",
+)
+@click.option(
+    "--auth-token",
+    help="Authentication token (if provided, auth is enabled)",
+)
+@click.option(
+    "--cors-origin",
+    multiple=True,
+    help="CORS allowed origins (can be specified multiple times)",
+)
+@click.option(
+    "--max-sessions",
+    type=int,
+    default=100,
+    help="Maximum number of concurrent sessions",
+)
+@click.option(
+    "--stateless",
+    is_flag=True,
+    help="Run in stateless mode",
+)
+def main(
+    backend: str,
+    host: str,
+    port: int,
+    server_path: str,
+    auth_token: Optional[str],
+    cors_origin: tuple[str, ...],
+    max_sessions: int,
+    stateless: bool,
+):
+    """Run the asyncmcp proxy server."""
+    print(f"🚀 Starting AsyncMCP Proxy Server")
+    print(f"   Backend: {backend}")
+    print(f"   Address: http://{host}:{port}{server_path}")
+    
+    if auth_token:
+        print(f"   Auth: Enabled (token required)")
+    else:
+        print(f"   Auth: Disabled")
+        
+    if cors_origin:
+        print(f"   CORS: {', '.join(cors_origin)}")
+        
+    print()
+    
+    # Create backend configuration
+    if backend == "sqs":
+        backend_config, backend_clients = create_sqs_backend_config()
+        backend_transport = "sqs"
+    elif backend == "sns-sqs":
+        backend_config, backend_clients = create_sns_sqs_backend_config()
+        backend_transport = "sns_sqs"
+    elif backend == "webhook":
+        backend_config, backend_clients = create_webhook_backend_config()
+        backend_transport = "webhook"
+    else:
+        raise ValueError(f"Unknown backend: {backend}")
+        
+    # Create proxy configuration
+    proxy_config = ProxyConfig(
+        host=host,
+        port=port,
+        server_path=server_path,
+        backend_transport=backend_transport,
+        backend_config=backend_config,
+        backend_clients=backend_clients,
+        max_sessions=max_sessions,
+        stateless=stateless,
+        auth_enabled=bool(auth_token),
+        auth_token=auth_token,
+        cors_origins=list(cors_origin) if cors_origin else None,
+    )
+    
+    # Create and run proxy server
+    proxy_server = ProxyServer(proxy_config)
+    
+    print("📡 Proxy server is ready to accept connections")
+    print(f"   MCP endpoint: http://{host}:{port}{server_path}")
+    print(f"   Health endpoint: http://{host}:{port}/health")
+    print()
+    print("ℹ️  The MCP endpoint handles both:")
+    print("   - GET requests for SSE connections")
+    print("   - POST requests for messages")
+    print()
+    print("Press Ctrl+C to stop the server")
+    
+    try:
+        asyncio.run(proxy_server.run())
+    except KeyboardInterrupt:
+        print("\n👋 Shutting down proxy server")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/proxy_server.py
+++ b/examples/proxy_server.py
@@ -9,13 +9,13 @@ This example demonstrates how to set up a proxy server that:
 Usage:
     # Start proxy with SQS backend
     python proxy_server.py --backend sqs
-    
+
     # Start proxy with SNS+SQS backend
     python proxy_server.py --backend sns-sqs
-    
+
     # Start proxy with authentication
     python proxy_server.py --backend sqs --auth-token "secret-token"
-    
+
     # Start proxy on custom port
     python proxy_server.py --backend sqs --port 9090
 """
@@ -61,14 +61,14 @@ DEFAULT_RESOURCES = {
 def create_sqs_backend_config() -> tuple[SqsClientConfig, dict]:
     """Create SQS backend configuration."""
     sqs_client = boto3.client("sqs", **AWS_CONFIG)
-    
+
     config = SqsClientConfig(
         read_queue_url=DEFAULT_RESOURCES["sqs_request_queue"],
         response_queue_url=DEFAULT_RESOURCES["sqs_response_queue"],
     )
-    
+
     backend_clients = {"sqs_client": sqs_client}
-    
+
     return config, backend_clients
 
 
@@ -76,17 +76,17 @@ def create_sns_sqs_backend_config() -> tuple[SnsSqsClientConfig, dict]:
     """Create SNS+SQS backend configuration."""
     sqs_client = boto3.client("sqs", **AWS_CONFIG)
     sns_client = boto3.client("sns", **AWS_CONFIG)
-    
+
     config = SnsSqsClientConfig(
         sns_topic_arn=DEFAULT_RESOURCES["sns_topic"],
         sqs_queue_url=DEFAULT_RESOURCES["sqs_response_queue"],
     )
-    
+
     backend_clients = {
         "sqs_client": sqs_client,
         "sns_client": sns_client,
     }
-    
+
     return config, backend_clients
 
 
@@ -95,9 +95,9 @@ def create_webhook_backend_config() -> tuple[WebhookClientConfig, dict]:
     config = WebhookClientConfig(
         server_url=DEFAULT_RESOURCES["webhook_server"],
     )
-    
+
     backend_clients = {}
-    
+
     return config, backend_clients
 
 
@@ -158,17 +158,17 @@ def main(
     print(f"🚀 Starting AsyncMCP Proxy Server")
     print(f"   Backend: {backend}")
     print(f"   Address: http://{host}:{port}{server_path}")
-    
+
     if auth_token:
         print(f"   Auth: Enabled (token required)")
     else:
         print(f"   Auth: Disabled")
-        
+
     if cors_origin:
         print(f"   CORS: {', '.join(cors_origin)}")
-        
+
     print()
-    
+
     # Create backend configuration
     if backend == "sqs":
         backend_config, backend_clients = create_sqs_backend_config()
@@ -181,7 +181,7 @@ def main(
         backend_transport = "webhook"
     else:
         raise ValueError(f"Unknown backend: {backend}")
-        
+
     # Create proxy configuration
     proxy_config = ProxyConfig(
         host=host,
@@ -196,10 +196,10 @@ def main(
         auth_token=auth_token,
         cors_origins=list(cors_origin) if cors_origin else None,
     )
-    
+
     # Create and run proxy server
     proxy_server = ProxyServer(proxy_config)
-    
+
     print("📡 Proxy server is ready to accept connections")
     print(f"   MCP endpoint: http://{host}:{port}{server_path}")
     print(f"   Health endpoint: http://{host}:{port}/health")
@@ -209,7 +209,7 @@ def main(
     print("   - POST requests for messages")
     print()
     print("Press Ctrl+C to stop the server")
-    
+
     try:
         asyncio.run(proxy_server.run())
     except KeyboardInterrupt:

--- a/src/asyncmcp/__init__.py
+++ b/src/asyncmcp/__init__.py
@@ -29,6 +29,9 @@ try:
 except PackageNotFoundError:
     __version__ = "0.0.0"
 
+# Proxy server
+from asyncmcp.proxy import ProxyConfig, ProxyServer, ProxySessionManager, create_proxy_server
+
 
 __all__ = [
     # SQS Transport
@@ -57,6 +60,11 @@ __all__ = [
     "StreamableHTTPWebhookConfig",
     "StreamableHTTPWebhookClientConfig",
     "webhook_tool",
+    # Proxy server
+    "ProxyConfig",
+    "ProxyServer",
+    "ProxySessionManager",
+    "create_proxy_server",
     # Package info
     "__version__",
 ]

--- a/src/asyncmcp/proxy/README.md
+++ b/src/asyncmcp/proxy/README.md
@@ -102,16 +102,6 @@ const tools = await client.listTools();
 - Sessions are automatically cleaned up on disconnect
 - Configurable session limits and timeouts
 
-### Authentication
-- Optional token-based authentication
-- Bearer token support in Authorization header
-- Easy to extend with custom auth mechanisms
-
-### CORS Support
-- Configurable CORS origins
-- Enables browser-based MCP clients
-- Full preflight request handling
-
 ### Error Handling
 - Graceful error propagation from backend
 - Client-friendly error messages
@@ -141,14 +131,6 @@ python examples/proxy_server.py --backend sqs --auth-token "secret"
 python examples/proxy_server.py --backend sqs --cors-origin "http://localhost:3000"
 ```
 
-## Use Cases
-
-1. **Gateway Functionality**: Single entry point for multiple backend services
-2. **Transport Abstraction**: Hide backend complexity from clients
-3. **Development**: Use standard tools while backend uses async transports
-4. **Security**: Add authentication layer to existing services
-5. **Load Distribution**: Route to multiple backend instances
-
 ## Testing
 
 Run the proxy tests:
@@ -156,10 +138,3 @@ Run the proxy tests:
 ```bash
 pytest tests/proxy/
 ```
-
-## Performance Considerations
-
-- Connection pooling for backend transports
-- Configurable timeouts and limits
-- Efficient streaming with SSE
-- Minimal overhead for message forwarding

--- a/src/asyncmcp/proxy/__init__.py
+++ b/src/asyncmcp/proxy/__init__.py
@@ -1,0 +1,16 @@
+"""AsyncMCP Proxy module.
+
+This module provides a proxy server that bridges standard MCP transports
+(StreamableHTTP/stdio) with asyncmcp's async transports (SQS, SNS+SQS, Webhook).
+"""
+
+from .manager import ProxySessionManager
+from .server import ProxyServer
+from .utils import ProxyConfig, create_proxy_server
+
+__all__ = [
+    "ProxyConfig",
+    "ProxyServer",
+    "ProxySessionManager",
+    "create_proxy_server",
+]

--- a/src/asyncmcp/proxy/__init__.py
+++ b/src/asyncmcp/proxy/__init__.py
@@ -4,13 +4,15 @@ This module provides a proxy server that bridges standard MCP transports
 (StreamableHTTP/stdio) with asyncmcp's async transports (SQS, SNS+SQS, Webhook).
 """
 
-from .manager import ProxySessionManager
 from .server import ProxyServer
+from .session import ProxySession
+from .session_manager import ProxySessionManager
 from .utils import ProxyConfig, create_proxy_server
 
 __all__ = [
     "ProxyConfig",
     "ProxyServer",
+    "ProxySession",
     "ProxySessionManager",
     "create_proxy_server",
 ]

--- a/src/asyncmcp/proxy/client.py
+++ b/src/asyncmcp/proxy/client.py
@@ -1,0 +1,184 @@
+"""Proxy client for connecting to asyncmcp backend transports.
+
+This module provides a client adapter that connects to various asyncmcp
+backend transports and provides a unified interface for the proxy server.
+"""
+
+import logging
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator, Dict, Optional, Tuple, Union
+
+from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
+from mcp.shared.message import SessionMessage
+
+from asyncmcp.sns_sqs.client import sns_sqs_client
+from asyncmcp.sns_sqs.utils import SnsSqsClientConfig
+from asyncmcp.sqs.client import sqs_client
+from asyncmcp.sqs.utils import SqsClientConfig
+from asyncmcp.streamable_http_webhook.client import streamable_http_webhook_client
+from asyncmcp.streamable_http_webhook.utils import StreamableHTTPWebhookClientConfig
+from asyncmcp.webhook.client import webhook_client
+from asyncmcp.webhook.utils import WebhookClientConfig
+
+from .utils import BackendConfig, BackendTransportType
+
+logger = logging.getLogger(__name__)
+
+
+class ProxyClient:
+    """Client adapter for connecting to asyncmcp backend transports.
+
+    This class provides a unified interface for connecting to different
+    asyncmcp transports from the proxy server. It handles transport-specific
+    connection logic and provides consistent stream interfaces.
+    """
+
+    def __init__(
+        self,
+        transport_type: BackendTransportType,
+        config: BackendConfig,
+        low_level_clients: Optional[Dict[str, Any]] = None,
+        session_id: Optional[str] = None,
+    ):
+        """Initialize the proxy client.
+
+        Args:
+            transport_type: The type of backend transport to connect to
+            config: Configuration for the backend transport
+            low_level_clients: Low-level clients (e.g., boto3) required by transport
+            session_id: Optional session ID for tracking
+        """
+        self.transport_type = transport_type
+        self.config = config
+        self.low_level_clients = low_level_clients or {}
+        self.session_id = session_id
+
+    @asynccontextmanager
+    async def connect(
+        self,
+    ) -> AsyncIterator[
+        Tuple[
+            MemoryObjectReceiveStream[Union[SessionMessage, Exception]],
+            MemoryObjectSendStream[SessionMessage],
+        ]
+    ]:
+        """Connect to the backend transport and yield streams.
+
+        This method establishes a connection to the configured backend
+        transport and yields read/write streams for communication.
+
+        Yields:
+            Tuple of (read_stream, write_stream) for bidirectional communication
+        """
+        if self.transport_type == "sqs":
+            async with self._connect_sqs() as streams:
+                yield streams
+
+        elif self.transport_type == "sns_sqs":
+            async with self._connect_sns_sqs() as streams:
+                yield streams
+
+        elif self.transport_type == "webhook":
+            async with self._connect_webhook() as streams:
+                yield streams
+
+        elif self.transport_type == "streamable_http_webhook":
+            async with self._connect_streamable_http_webhook() as streams:
+                yield streams
+
+        else:
+            raise ValueError(f"Unsupported transport type: {self.transport_type}")
+
+    @asynccontextmanager
+    async def _connect_sqs(self):
+        """Connect to SQS backend."""
+        if "sqs_client" not in self.low_level_clients:
+            raise ValueError("SQS transport requires 'sqs_client' in low_level_clients")
+
+        config = self.config
+        if not isinstance(config, SqsClientConfig):
+            raise TypeError(f"Expected SqsClientConfig, got {type(config)}")
+
+        logger.info(f"ProxyClient[{self.session_id}]: Connecting to SQS backend with config: {config}")
+        async with sqs_client(
+            config=config,
+            sqs_client=self.low_level_clients["sqs_client"],
+        ) as (read_stream, write_stream):
+            logger.info(f"ProxyClient[{self.session_id}]: Connected to SQS backend successfully")
+            logger.info(f"ProxyClient[{self.session_id}]: Read queue: {config.read_queue_url}")
+            logger.info(f"ProxyClient[{self.session_id}]: Response queue: {config.response_queue_url}")
+            yield read_stream, write_stream
+
+    @asynccontextmanager
+    async def _connect_sns_sqs(self):
+        """Connect to SNS+SQS backend."""
+        if "sqs_client" not in self.low_level_clients:
+            raise ValueError("SNS+SQS transport requires 'sqs_client' in low_level_clients")
+        if "sns_client" not in self.low_level_clients:
+            raise ValueError("SNS+SQS transport requires 'sns_client' in low_level_clients")
+
+        config = self.config
+        if not isinstance(config, SnsSqsClientConfig):
+            raise TypeError(f"Expected SnsSqsClientConfig, got {type(config)}")
+
+        async with sns_sqs_client(
+            config=config,
+            sqs_client=self.low_level_clients["sqs_client"],
+            sns_client=self.low_level_clients["sns_client"],
+            client_topic_arn=config.sns_topic_arn,  # Use the topic from config
+        ) as (read_stream, write_stream):
+            logger.debug(f"ProxyClient[{self.session_id}]: Connected to SNS+SQS backend")
+            yield read_stream, write_stream
+
+    @asynccontextmanager
+    async def _connect_webhook(self):
+        """Connect to Webhook backend."""
+        config = self.config
+        if not isinstance(config, WebhookClientConfig):
+            raise TypeError(f"Expected WebhookClientConfig, got {type(config)}")
+
+        async with webhook_client(config=config) as streams:
+            # webhook_client returns a 3-tuple, we only need the first two
+            read_stream, write_stream = streams[0], streams[1]
+            logger.debug(f"ProxyClient[{self.session_id}]: Connected to Webhook backend")
+            yield read_stream, write_stream
+
+    @asynccontextmanager
+    async def _connect_streamable_http_webhook(self):
+        """Connect to StreamableHTTP+Webhook backend."""
+        config = self.config
+        if not isinstance(config, StreamableHTTPWebhookClientConfig):
+            raise TypeError(f"Expected StreamableHTTPWebhookClientConfig, got {type(config)}")
+
+        async with streamable_http_webhook_client(config=config) as streams:
+            # streamable_http_webhook_client returns a 3-tuple, we only need the first two
+            read_stream, write_stream = streams[0], streams[1]
+            logger.debug(f"ProxyClient[{self.session_id}]: Connected to StreamableHTTP+Webhook backend")
+            yield read_stream, write_stream
+
+
+def create_backend_client(
+    transport_type: BackendTransportType,
+    config: BackendConfig,
+    low_level_clients: Optional[Dict[str, Any]] = None,
+    session_id: Optional[str] = None,
+) -> ProxyClient:
+    """Create a backend client for the specified transport.
+
+    This is a convenience function for creating ProxyClient instances.
+
+    Args:
+        transport_type: The type of backend transport
+        config: Configuration for the backend transport
+        low_level_clients: Low-level clients required by transport
+        session_id: Optional session ID for tracking
+
+    Returns:
+        ProxyClient: Configured client instance
+    """
+    return ProxyClient(
+        transport_type=transport_type,
+        config=config,
+        low_level_clients=low_level_clients,
+        session_id=session_id,
+    )

--- a/src/asyncmcp/proxy/client.py
+++ b/src/asyncmcp/proxy/client.py
@@ -99,14 +99,10 @@ class ProxyClient:
         if not isinstance(config, SqsClientConfig):
             raise TypeError(f"Expected SqsClientConfig, got {type(config)}")
 
-        logger.info(f"ProxyClient[{self.session_id}]: Connecting to SQS backend with config: {config}")
         async with sqs_client(
             config=config,
             sqs_client=self.low_level_clients["sqs_client"],
         ) as (read_stream, write_stream):
-            logger.info(f"ProxyClient[{self.session_id}]: Connected to SQS backend successfully")
-            logger.info(f"ProxyClient[{self.session_id}]: Read queue: {config.read_queue_url}")
-            logger.info(f"ProxyClient[{self.session_id}]: Response queue: {config.response_queue_url}")
             yield read_stream, write_stream
 
     @asynccontextmanager

--- a/src/asyncmcp/proxy/interceptor.py
+++ b/src/asyncmcp/proxy/interceptor.py
@@ -1,0 +1,58 @@
+import logging
+from typing import Protocol
+
+from anyio.streams.memory import MemoryObjectSendStream
+from mcp.shared.message import SessionMessage
+
+logger = logging.getLogger(__name__)
+
+
+class ResponseHandler(Protocol):
+    """Protocol for response handling."""
+
+    def _handle_response(self, session_id: str, message: SessionMessage) -> bool:
+        """Handle a response from the backend."""
+        ...
+
+
+class InterceptingStream:
+    """Stream wrapper that intercepts responses for synchronous handling.
+
+    This class wraps a MemoryObjectSendStream and intercepts messages
+    to check if they should be handled synchronously (for pending requests)
+    or forwarded to the SSE stream.
+    """
+
+    def __init__(
+        self,
+        manager: ResponseHandler,
+        session_id: str,
+        stream: MemoryObjectSendStream[SessionMessage],
+    ):
+        """Initialize the intercepting stream.
+
+        Args:
+            manager: The session manager that handles responses
+            session_id: Session ID for this stream
+            stream: The underlying stream to wrap
+        """
+        self.manager = manager
+        self.session_id = session_id
+        self.stream = stream
+
+    async def send(self, message: SessionMessage):
+        """Send a message, intercepting for synchronous handling.
+
+        Args:
+            message: The message to send
+        """
+        # Check if this message should be handled synchronously
+        should_forward = self.manager._handle_response(self.session_id, message)
+        if should_forward:
+            # Forward to SSE
+            await self.stream.send(message)
+        # Otherwise it was handled by a pending request
+
+    async def aclose(self):
+        """Close the underlying stream."""
+        await self.stream.aclose()

--- a/src/asyncmcp/proxy/manager.py
+++ b/src/asyncmcp/proxy/manager.py
@@ -1,0 +1,449 @@
+"""Proxy session manager implementation.
+
+This module manages proxy sessions and routes messages between the
+StreamableHTTP frontend and asyncmcp backend transports.
+"""
+
+import asyncio
+import logging
+from typing import Any, Dict, Optional, Union
+
+import anyio
+from anyio.abc import TaskGroup
+from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
+from mcp.shared.message import SessionMessage
+from mcp.types import ErrorData, JSONRPCMessage
+
+from .client import ProxyClient, create_backend_client
+from .utils import ProxyConfig, generate_session_id
+
+logger = logging.getLogger(__name__)
+
+
+class ProxySession:
+    """Represents a single proxy session.
+
+    Each session maintains a connection to the backend transport and
+    manages message routing between the client and backend.
+    """
+
+    def __init__(
+        self,
+        session_id: str,
+        backend_client: ProxyClient,
+        response_sender: MemoryObjectSendStream[SessionMessage],
+    ):
+        """Initialize a proxy session.
+
+        Args:
+            session_id: Unique session identifier
+            backend_client: Client for connecting to backend transport
+            response_sender: Stream for sending responses to the client
+        """
+        self.session_id = session_id
+        self.backend_client = backend_client
+        self.response_sender = response_sender
+
+        self._task_group: Optional[TaskGroup] = None
+        self._read_stream: Optional[MemoryObjectReceiveStream[Union[SessionMessage, Exception]]] = None
+        self._write_stream: Optional[MemoryObjectSendStream[SessionMessage]] = None
+        self._running = False
+        self._connected_event = anyio.Event()
+
+    async def start(self):
+        """Start the proxy session."""
+        if self._running:
+            return
+
+        self._running = True
+        logger.info(f"Starting proxy session {self.session_id}")
+
+        async with anyio.create_task_group() as tg:
+            self._task_group = tg
+
+            # Connect to backend
+            logger.info(f"Connecting to backend for session {self.session_id}")
+            try:
+                async with self.backend_client.connect() as (read_stream, write_stream):
+                    self._read_stream = read_stream
+                    self._write_stream = write_stream
+                    logger.info(f"Backend connected successfully for session {self.session_id}")
+                    logger.info(f"Read stream: {type(read_stream)}, Write stream: {type(write_stream)}")
+                    
+                    # Signal that we're connected
+                    self._connected_event.set()
+
+                    # Start forwarding messages from backend to client
+                    tg.start_soon(self._forward_responses)
+
+                    # Keep session alive until cancelled
+                    try:
+                        await anyio.Event().wait()
+                    except asyncio.CancelledError:
+                        logger.info(f"Proxy session {self.session_id} cancelled")
+                        raise
+            except Exception as e:
+                logger.error(f"Failed to connect to backend for session {self.session_id}: {type(e).__name__}: {e}")
+                import traceback
+                logger.error(f"Traceback: {traceback.format_exc()}")
+                raise
+
+    async def stop(self):
+        """Stop the proxy session."""
+        if not self._running:
+            return
+
+        self._running = False
+        logger.info(f"Stopping proxy session {self.session_id}")
+
+        if self._task_group:
+            self._task_group.cancel_scope.cancel()
+
+    async def send_message(self, message_data: Dict[str, Any]):
+        """Send a message to the backend.
+
+        Args:
+            message_data: JSON-RPC message data to send
+        """
+        logger.info(f"Session {self.session_id} sending message: method={message_data.get('method', 'unknown')}, id={message_data.get('id', 'none')}")
+        
+        # Wait for connection to be established
+        logger.debug(f"Waiting for connection event for session {self.session_id}...")
+        await self._connected_event.wait()
+        logger.debug(f"Connection event received for session {self.session_id}")
+        
+        if not self._write_stream:
+            logger.error(f"Write stream is None for session {self.session_id}")
+            raise RuntimeError("Session not connected")
+
+        try:
+            # Parse and validate message
+            logger.debug(f"Parsing message data: {message_data}")
+            jsonrpc_message = JSONRPCMessage.model_validate(message_data)
+            session_message = SessionMessage(jsonrpc_message)
+            logger.debug(f"Created SessionMessage: {session_message}")
+
+            # Send to backend
+            logger.info(f"Sending message to backend via write stream for session {self.session_id}")
+            await self._write_stream.send(session_message)
+            logger.info(f"Message sent successfully to backend for session {self.session_id}")
+
+        except Exception as e:
+            logger.error(f"Session {self.session_id}: Error sending message: {e}")
+            raise
+
+    async def _forward_responses(self):
+        """Forward responses from backend to client."""
+        if not self._read_stream:
+            return
+
+        logger.info(f"Starting response forwarding for session {self.session_id}")
+        try:
+            async for message in self._read_stream:
+                logger.info(f"Received message from backend for session {self.session_id}: {type(message)}")
+                if isinstance(message, Exception):
+                    # Handle backend errors
+                    logger.error(f"Backend error for session {self.session_id}: {message}")
+                    error_response = self._create_error_response(str(message))
+                    await self.response_sender.send(error_response)
+                else:
+                    # Forward response to client
+                    logger.info(f"Forwarding response to client for session {self.session_id}")
+                    await self.response_sender.send(message)
+                    logger.info(f"Session {self.session_id}: Successfully forwarded response to client")
+
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error(f"Session {self.session_id}: Error forwarding responses: {e}")
+
+    def _create_error_response(self, error_message: str) -> SessionMessage:
+        """Create an error response message."""
+        error_data = ErrorData(
+            code=-32603,  # Internal error
+            message=error_message,
+        )
+        jsonrpc_message = JSONRPCMessage.model_validate(
+            {
+                "jsonrpc": "2.0",
+                "error": error_data.model_dump(),
+            }
+        )
+        return SessionMessage(jsonrpc_message)
+
+
+class ProxySessionManager:
+    """Manages proxy sessions and message routing.
+
+    This class handles session lifecycle, message routing between clients
+    and backend transports, and resource management.
+    """
+
+    def __init__(self, config: ProxyConfig):
+        """Initialize the session manager.
+
+        Args:
+            config: Proxy configuration
+        """
+        self.config = config
+        self._sessions: Dict[str, ProxySession] = {}
+        self._response_streams: Dict[str, MemoryObjectSendStream[SessionMessage]] = {}
+        self._response_receivers: Dict[str, MemoryObjectReceiveStream[SessionMessage]] = {}
+        self._task_group: Optional[TaskGroup] = None
+        self._running = False
+        # Track pending responses for synchronous request/response pattern
+        self._pending_responses: Dict[str, asyncio.Future] = {}
+
+    @property
+    def active_session_count(self) -> int:
+        """Get the number of active sessions."""
+        return len(self._sessions)
+
+    def create_session_id(self) -> str:
+        """Create a new unique session ID."""
+        return generate_session_id()
+
+    def has_session(self, session_id: str) -> bool:
+        """Check if a session exists.
+
+        Args:
+            session_id: Session ID to check
+
+        Returns:
+            bool: True if session exists
+        """
+        return session_id in self._sessions
+    
+    def get_single_session_id(self) -> Optional[str]:
+        """Get the session ID if there's only one active session.
+        
+        This is used to support clients like MCP Inspector that expect
+        a single session per server instance.
+        
+        Returns:
+            str: The session ID if there's exactly one session, None otherwise
+        """
+        if len(self._sessions) == 1:
+            return next(iter(self._sessions.keys()))
+        return None
+
+    async def start(self):
+        """Start the session manager."""
+        if self._running:
+            return
+
+        self._running = True
+        logger.info("Starting proxy session manager")
+
+    async def stop(self):
+        """Stop the session manager and clean up all sessions."""
+        if not self._running:
+            return
+
+        self._running = False
+        logger.info("Stopping proxy session manager")
+
+        # Stop all sessions
+        for session_id in list(self._sessions.keys()):
+            await self.remove_session(session_id)
+
+    async def get_response_stream(self, session_id: str) -> MemoryObjectReceiveStream[SessionMessage]:
+        """Get the response stream for a session.
+
+        This creates a new session if it doesn't exist.
+
+        Args:
+            session_id: Session ID
+
+        Returns:
+            Stream for receiving responses from the backend
+        """
+        if session_id not in self._sessions:
+            await self._create_session(session_id)
+
+        return self._response_receivers[session_id]
+
+    async def send_message(self, session_id: str, message_data: Dict[str, Any]):
+        """Send a message to a session's backend.
+
+        Args:
+            session_id: Session ID
+            message_data: Message data to send
+        """
+        session = self._sessions.get(session_id)
+        if not session:
+            raise ValueError(f"Session {session_id} not found")
+
+        await session.send_message(message_data)
+
+    async def wait_for_response(self, session_id: str, request_id: Any, timeout: float = 10.0) -> Optional[str]:
+        """Wait for a specific response from the backend.
+        
+        Args:
+            session_id: Session ID
+            request_id: Request ID to wait for
+            timeout: Maximum time to wait in seconds
+            
+        Returns:
+            JSON string of the response, or None if timeout
+        """
+        # Create a future to wait for the response
+        future_key = f"{session_id}:{request_id}"
+        future = asyncio.get_event_loop().create_future()
+        self._pending_responses[future_key] = future
+        
+        try:
+            # Wait for the response with timeout
+            response = await asyncio.wait_for(future, timeout=timeout)
+            return response
+        except asyncio.TimeoutError:
+            logger.warning(f"Timeout waiting for response to request {request_id}")
+            return None
+        except Exception as e:
+            logger.error(f"Error waiting for response: {e}")
+            return None
+        finally:
+            # Clean up the future
+            self._pending_responses.pop(future_key, None)
+            
+    def _handle_response(self, session_id: str, message: SessionMessage) -> bool:
+        """Handle a response from the backend, checking for pending requests.
+        
+        Args:
+            session_id: Session ID
+            message: Response message
+            
+        Returns:
+            True if message should be forwarded to SSE, False if handled synchronously
+        """
+        # Check if this is a response to a pending request
+        message_dict = message.message.model_dump(exclude_none=True, by_alias=True)
+        request_id = message_dict.get("id")
+        
+        if request_id is not None:  # Changed from if request_id to handle id=0
+            future_key = f"{session_id}:{request_id}"
+            future = self._pending_responses.get(future_key)
+            
+            if future and not future.done():
+                # Fulfill the pending request
+                response_json = message.message.model_dump_json(
+                    exclude_none=True,
+                    by_alias=True,
+                )
+                future.set_result(response_json)
+                logger.info(f"Fulfilled pending response for request {request_id}")
+                # Don't forward to SSE since it was handled synchronously
+                return False
+                
+        # Forward to SSE stream
+        return True
+        
+    def _create_intercepting_stream(self, session_id: str, original_stream: MemoryObjectSendStream[SessionMessage]) -> MemoryObjectSendStream[SessionMessage]:
+        """Create a wrapper stream that intercepts responses.
+        
+        Args:
+            session_id: Session ID
+            original_stream: Original send stream
+            
+        Returns:
+            Wrapped stream that intercepts messages
+        """
+        class InterceptingStream:
+            def __init__(self, manager, session_id, stream):
+                self.manager = manager
+                self.session_id = session_id
+                self.stream = stream
+                
+            async def send(self, message: SessionMessage):
+                # Check if this message should be handled synchronously
+                should_forward = self.manager._handle_response(self.session_id, message)
+                if should_forward:
+                    # Forward to SSE
+                    await self.stream.send(message)
+                # Otherwise it was handled by a pending request
+                
+            async def aclose(self):
+                await self.stream.aclose()
+                
+        return InterceptingStream(self, session_id, original_stream)
+
+    async def remove_session(self, session_id: str):
+        """Remove a session and clean up its resources.
+
+        Args:
+            session_id: Session ID to remove
+        """
+        session = self._sessions.pop(session_id, None)
+        if session:
+            await session.stop()
+
+        # Clean up streams
+        sender = self._response_streams.pop(session_id, None)
+        if sender:
+            await sender.aclose()
+
+        receiver = self._response_receivers.pop(session_id, None)
+        if receiver:
+            await receiver.aclose()
+
+        logger.info(f"Removed session {session_id}")
+
+    async def _create_session(self, session_id: str):
+        """Create a new proxy session.
+
+        Args:
+            session_id: Session ID for the new session
+        """
+        if session_id in self._sessions:
+            return
+
+        # Check session limit
+        if len(self._sessions) >= self.config.max_sessions:
+            raise RuntimeError(f"Maximum session limit ({self.config.max_sessions}) reached")
+
+        logger.info(f"Creating proxy session {session_id}")
+
+        # Create response streams
+        send_stream, receive_stream = anyio.create_memory_object_stream[SessionMessage](100)
+        self._response_streams[session_id] = send_stream
+        self._response_receivers[session_id] = receive_stream
+
+        # Create backend client
+        logger.info(f"Creating backend client for transport: {self.config.backend_transport}")
+        logger.info(f"Backend config: {self.config.backend_config}")
+        logger.info(f"Backend clients: {self.config.backend_clients}")
+        backend_client = create_backend_client(
+            transport_type=self.config.backend_transport,
+            config=self.config.backend_config,  # type: ignore[arg-type]
+            low_level_clients=self.config.backend_clients,
+            session_id=session_id,
+        )
+        logger.info(f"Backend client created: {type(backend_client).__name__} for session {session_id}")
+
+        # Create a wrapper send stream that intercepts responses
+        wrapped_send_stream = self._create_intercepting_stream(session_id, send_stream)
+        
+        # Create and start session
+        session = ProxySession(
+            session_id=session_id,
+            backend_client=backend_client,
+            response_sender=wrapped_send_stream,
+        )
+        self._sessions[session_id] = session
+
+        # Start session in background
+        asyncio.create_task(self._run_session(session))
+
+    async def _run_session(self, session: ProxySession):
+        """Run a session in the background.
+
+        Args:
+            session: Session to run
+        """
+        try:
+            await session.start()
+        except Exception as e:
+            logger.error(f"Session {session.session_id} error: {e}")
+        finally:
+            # Clean up session
+            await self.remove_session(session.session_id)

--- a/src/asyncmcp/proxy/message_handler.py
+++ b/src/asyncmcp/proxy/message_handler.py
@@ -1,0 +1,144 @@
+import json
+import logging
+from typing import Any, Dict, Optional, Protocol
+
+from starlette.responses import Response
+
+logger = logging.getLogger(__name__)
+
+
+class SessionManagerProtocol(Protocol):
+    """Protocol for session manager."""
+
+    async def send_message(self, session_id: str, message_data: Dict[str, Any]):
+        """Send a message to a session."""
+        ...
+
+    async def wait_for_response(self, session_id: str, request_id: Any, timeout: float) -> Optional[str]:
+        """Wait for a response from a session."""
+        ...
+
+    async def get_response_stream(self, session_id: str) -> Any:
+        """Get or create response stream for a session."""
+        ...
+
+    def has_session(self, session_id: str) -> bool:
+        """Check if a session exists."""
+        ...
+
+
+class MessageHandler:
+    """Handles different types of messages in the proxy.
+
+    This class encapsulates the logic for handling notifications,
+    requests, and responses.
+    """
+
+    def __init__(self, session_manager: SessionManagerProtocol):
+        """Initialize the message handler.
+
+        Args:
+            session_manager: The session manager to use
+        """
+        self.session_manager = session_manager
+
+    async def handle_notification(
+        self, session_id: str, message_data: Dict[str, Any], is_new_session: bool
+    ) -> Response:
+        """Handle a notification message.
+
+        Args:
+            session_id: The session ID
+            message_data: The message data
+            is_new_session: Whether this is a new session
+
+        Returns:
+            HTTP response
+        """
+        await self.session_manager.send_message(session_id, message_data)
+
+        # Return 204 No Content for notifications
+        return Response(
+            status_code=204,
+            headers={"X-Session-Id": session_id} if is_new_session else {},
+        )
+
+    async def handle_request(
+        self, session_id: str, message_data: Dict[str, Any], is_new_session: bool, timeout: float = 300.0
+    ) -> Response:
+        """Handle a regular request message.
+
+        Args:
+            session_id: The session ID
+            message_data: The message data
+            is_new_session: Whether this is a new session
+            timeout: Timeout for waiting for response
+
+        Returns:
+            HTTP response
+        """
+        # Forward message to backend
+        await self.session_manager.send_message(session_id, message_data)
+
+        # Get the request ID to wait for the response
+        request_id = message_data.get("id")
+
+        # Wait for the response from backend (with timeout)
+        logger.info(f"Waiting for response to request {request_id} from backend...")
+
+        response_data = await self.session_manager.wait_for_response(session_id, request_id, timeout=timeout)
+
+        if response_data:
+            # Return the JSON-RPC response directly
+            logger.info(f"Returning response for request {request_id} directly in POST response")
+            return Response(
+                status_code=200,
+                content=response_data,
+                media_type="application/json",
+                headers={"X-Session-Id": session_id} if is_new_session else {},
+            )
+        else:
+            # Timeout or error - return error response
+            logger.error(f"Timeout waiting for response to request {request_id}")
+            error_response = {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {"code": -32001, "message": "Request timed out"},
+            }
+            return Response(
+                status_code=200,
+                content=json.dumps(error_response),
+                media_type="application/json",
+                headers={"X-Session-Id": session_id} if is_new_session else {},
+            )
+
+    def is_notification(self, message_data: Dict[str, Any]) -> bool:
+        """Check if a message is a notification.
+
+        Args:
+            message_data: The message data
+
+        Returns:
+            True if the message is a notification
+        """
+        return message_data.get("method", "").startswith("notifications/")
+
+    async def ensure_session_exists(self, session_id: str, is_new_session: bool) -> bool:
+        """Ensure a session exists, creating it if needed.
+
+        Args:
+            session_id: The session ID
+            is_new_session: Whether this is marked as a new session
+
+        Returns:
+            True if session exists or was created
+        """
+        if is_new_session or not self.session_manager.has_session(session_id):
+            await self.session_manager.get_response_stream(session_id)
+            return True
+
+        # Check if session exists (skip for new sessions)
+        if not is_new_session and not self.session_manager.has_session(session_id):
+            return False
+
+        return True

--- a/src/asyncmcp/proxy/server.py
+++ b/src/asyncmcp/proxy/server.py
@@ -1,0 +1,401 @@
+"""Proxy server implementation.
+
+This module provides a StreamableHTTP server that acts as a proxy,
+forwarding requests to asyncmcp backend transports.
+"""
+
+import asyncio
+import json
+import logging
+
+import uvicorn
+from starlette.applications import Starlette
+from starlette.middleware.cors import CORSMiddleware
+from starlette.requests import Request
+from starlette.responses import Response, StreamingResponse
+from starlette.routing import Route
+
+from .manager import ProxySessionManager
+from .utils import ProxyConfig, validate_auth_token
+
+logger = logging.getLogger(__name__)
+
+
+class ProxyServer:
+    """StreamableHTTP proxy server for asyncmcp transports.
+
+    This server exposes a standard MCP StreamableHTTP endpoint and forwards
+    requests to configured asyncmcp backend transports (SQS, SNS+SQS, etc.).
+    """
+
+    def __init__(self, config: ProxyConfig):
+        """Initialize the proxy server.
+
+        Args:
+            config: Proxy server configuration
+        """
+        self.config = config
+        self.session_manager = ProxySessionManager(config)
+
+        # Create Starlette app with routes
+        self.app = Starlette(
+            routes=[
+                Route(config.server_path, self.handle_request, methods=["GET", "POST"]),
+                Route("/health", self.handle_health, methods=["GET"]),
+            ],
+            on_startup=[self.startup],
+            on_shutdown=[self.shutdown],
+        )
+
+        # Add CORS middleware if configured
+        if config.cors_origins:
+            self.app.add_middleware(
+                CORSMiddleware,
+                allow_origins=config.cors_origins,
+                allow_credentials=True,
+                allow_methods=["GET", "POST"],
+                allow_headers=["*"],
+            )
+
+    async def startup(self):
+        """Initialize server resources on startup."""
+        logger.info(
+            f"Starting proxy server on {self.config.host}:{self.config.port} "
+            f"with backend transport: {self.config.backend_transport}"
+        )
+        await self.session_manager.start()
+
+    async def shutdown(self):
+        """Clean up server resources on shutdown."""
+        logger.info("Shutting down proxy server")
+        await self.session_manager.stop()
+
+    async def handle_health(self, request: Request) -> Response:
+        """Health check endpoint."""
+        return Response(
+            content=json.dumps(
+                {
+                    "status": "healthy",
+                    "backend_transport": self.config.backend_transport,
+                    "active_sessions": self.session_manager.active_session_count,
+                }
+            ),
+            media_type="application/json",
+        )
+
+    async def handle_request(self, request: Request) -> Response:
+        """Handle all requests to the MCP endpoint.
+        
+        Routes based on HTTP method:
+        - GET: Establish SSE connection
+        - POST: Handle message requests
+        """
+        if request.method == "GET":
+            return await self.handle_sse(request)
+        elif request.method == "POST":
+            return await self.handle_message(request)
+        else:
+            return Response(
+                status_code=405,
+                content=json.dumps({"error": "Method not allowed"}),
+                media_type="application/json",
+                headers={"Allow": "GET, POST"},
+            )
+
+    async def handle_sse(self, request: Request) -> StreamingResponse:
+        """Handle Server-Sent Events (SSE) connection for StreamableHTTP.
+
+        This endpoint establishes an SSE connection with the client and
+        streams responses from the backend transport.
+        """
+        # Validate authentication if enabled
+        if self.config.auth_enabled:
+            auth_header = request.headers.get("Authorization", "")
+            token = auth_header.replace("Bearer ", "") if auth_header.startswith("Bearer ") else ""
+            if not validate_auth_token(token, self.config.auth_token):
+                return Response(status_code=401, content="Unauthorized")
+
+        # Get or create session
+        session_id = request.headers.get("X-Session-Id")
+        if not session_id:
+            session_id = self.session_manager.create_session_id()
+            logger.info(f"New SSE connection from {request.client.host}, assigned session {session_id}")
+        else:
+            logger.info(f"Existing SSE connection from {request.client.host}, session {session_id}")
+
+        # Create SSE response
+        async def event_generator():
+            """Generate SSE events from backend responses."""
+            try:
+                # Get response stream for this session
+                response_stream = await self.session_manager.get_response_stream(session_id)
+
+                # Stream responses from backend
+                async for message in response_stream:
+                    # Convert SessionMessage to JSON
+                    message_data = message.message.model_dump_json(
+                        exclude_none=True,
+                        by_alias=True,
+                    )
+
+                    # Send as SSE event
+                    yield f"event: message\ndata: {message_data}\n\n"
+
+            except asyncio.CancelledError:
+                logger.info(f"SSE connection closed for session {session_id}")
+                raise
+            except Exception as e:
+                logger.error(f"Error in SSE stream for session {session_id}: {e}")
+                error_data = json.dumps({"error": str(e), "type": "stream_error"})
+                yield f"event: error\ndata: {error_data}\n\n"
+            finally:
+                # Don't remove session here - sessions should persist beyond SSE connections
+                # This allows clients like MCP Inspector to reconnect or make subsequent requests
+                logger.info(f"SSE stream ended for session {session_id}, but session remains active")
+
+        response = StreamingResponse(
+            event_generator(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "X-Session-Id": session_id,
+            },
+        )
+        
+        # Set session cookie for browser-based clients
+        response.set_cookie(
+            key="mcp-session-id",
+            value=session_id,
+            httponly=True,
+            samesite="lax",
+            max_age=86400  # 24 hours
+        )
+        
+        return response
+
+    async def _create_sse_response_for_request(self, session_id: str, request_id: str) -> StreamingResponse:
+        """Create an SSE response stream for a specific request."""
+        async def request_event_generator():
+            """Generate SSE events for a specific request response."""
+            try:
+                # Get response stream for this session
+                response_stream = await self.session_manager.get_response_stream(session_id)
+                
+                # Wait for the specific response
+                async for message in response_stream:
+                    # Check if this is the response we're waiting for
+                    message_dict = message.message.model_dump(exclude_none=True, by_alias=True)
+                    if message_dict.get("id") == request_id:
+                        # Send the response as SSE event
+                        message_data = message.message.model_dump_json(
+                            exclude_none=True,
+                            by_alias=True,
+                        )
+                        yield f"event: message\ndata: {message_data}\n\n"
+                        break
+                    # Also forward any notifications or messages without ID
+                    elif "id" not in message_dict:
+                        message_data = message.message.model_dump_json(
+                            exclude_none=True,
+                            by_alias=True,
+                        )
+                        yield f"event: message\ndata: {message_data}\n\n"
+                        
+            except Exception as e:
+                logger.error(f"Error in SSE response stream: {e}")
+                error_data = json.dumps({"error": str(e), "type": "stream_error"})
+                yield f"event: error\ndata: {error_data}\n\n"
+        
+        return StreamingResponse(
+            request_event_generator(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "X-Session-Id": session_id,
+            },
+        )
+
+    async def handle_message(self, request: Request) -> Response:
+        """Handle message POST endpoint for StreamableHTTP.
+
+        This endpoint receives messages from the client and forwards them
+        to the backend transport. Returns SSE stream if Accept header includes
+        text/event-stream, otherwise returns JSON response.
+        """
+        # Validate authentication if enabled
+        if self.config.auth_enabled:
+            auth_header = request.headers.get("Authorization", "")
+            token = auth_header.replace("Bearer ", "") if auth_header.startswith("Bearer ") else ""
+            if not validate_auth_token(token, self.config.auth_token):
+                return Response(status_code=401, content="Unauthorized")
+
+        # Check Accept header to determine response type
+        accept_header = request.headers.get("accept", "")
+        accepts_sse = "text/event-stream" in accept_header
+        accepts_json = "application/json" in accept_header or "*/*" in accept_header
+        
+        # Debug logging for MCP Inspector
+        logger.info(f"POST request Accept header: '{accept_header}'")
+        logger.info(f"Accepts SSE: {accepts_sse}, Accepts JSON: {accepts_json}")
+
+        # Parse request body first to check if it's an initialize request
+        try:
+            body = await request.body()
+            message_data = json.loads(body)
+            is_initialize = message_data.get("method") == "initialize"
+        except json.JSONDecodeError as e:
+            return Response(
+                status_code=400,
+                content=json.dumps({"error": f"Invalid JSON: {str(e)}"}),
+                media_type="application/json",
+            )
+        
+        # Get session ID from various sources
+        session_id = None
+        is_new_session = False
+        
+        # Debug logging
+        logger.debug(f"Request method: {request.method}, is_initialize: {is_initialize}")
+        logger.debug(f"Headers: {dict(request.headers)}")
+        logger.debug(f"Active sessions: {self.session_manager.active_session_count}")
+        
+        # 1. Check X-Session-Id header (for clients that support it)
+        session_id = request.headers.get("X-Session-Id")
+        if session_id:
+            logger.debug(f"Found session ID in X-Session-Id header: {session_id}")
+        
+        # 2. Check cookies for session (for browser-based clients like MCP Inspector)
+        if not session_id and "cookie" in request.headers:
+            cookies = request.cookies
+            session_id = cookies.get("mcp-session-id")
+            if session_id:
+                logger.debug(f"Found session ID in cookie: {session_id}")
+        
+        # 3. For stateless mode or single session, use a default session
+        if not session_id and (self.config.stateless or is_initialize):
+            # In stateless mode or for initialize, use/create a default session
+            if self.config.stateless:
+                session_id = "default"
+                logger.debug("Using default session for stateless mode")
+            elif is_initialize:
+                # For initialize, try to use existing session if there's only one
+                if self.session_manager.active_session_count == 1:
+                    session_id = self.session_manager.get_single_session_id()
+                    logger.info(f"Using existing single session for initialize: {session_id}")
+                else:
+                    # Create new session for initialize requests
+                    session_id = self.session_manager.create_session_id()
+                    is_new_session = True
+                    logger.info(f"New session created for initialize request: {session_id}")
+        
+        # 4. If still no session ID and not initialize, try to get the first/only active session
+        # This supports MCP Inspector which expects a single session per server
+        if not session_id and self.session_manager.active_session_count == 1:
+            # Get the single active session
+            session_id = self.session_manager.get_single_session_id()
+            if session_id:
+                logger.info(f"Using single active session: {session_id}")
+        
+        # 5. Final check - if no session ID found, return error
+        if not session_id:
+            logger.error(f"No session ID found. Active sessions: {self.session_manager.active_session_count}")
+            return Response(
+                status_code=400,
+                content=json.dumps({"error": "No active session. Please initialize first."}),
+                media_type="application/json",
+            )
+        
+        # Create session if needed
+        if is_new_session or not self.session_manager.has_session(session_id):
+            await self.session_manager.get_response_stream(session_id)
+
+        # Check if session exists (skip for new sessions)
+        if not is_new_session and not self.session_manager.has_session(session_id):
+            return Response(
+                status_code=404,
+                content=json.dumps({"error": "Session not found"}),
+                media_type="application/json",
+            )
+
+        try:
+            # Forward message to backend
+            await self.session_manager.send_message(session_id, message_data)
+            
+            # Get the request ID to wait for the response
+            request_id = message_data.get("id")
+            
+            # Wait for the response from backend (with timeout)
+            logger.info(f"Waiting for response to request {request_id} from backend...")
+            
+            response_data = await self.session_manager.wait_for_response(
+                session_id, request_id, timeout=10.0
+            )
+            
+            if response_data:
+                # Return the JSON-RPC response directly
+                logger.info(f"Returning response for request {request_id} directly in POST response")
+                response = Response(
+                    status_code=200,
+                    content=response_data,
+                    media_type="application/json",
+                    headers={"X-Session-Id": session_id} if is_new_session else {},
+                )
+            else:
+                # Timeout or error - return error response
+                logger.error(f"Timeout waiting for response to request {request_id}")
+                error_response = {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "error": {
+                        "code": -32001,
+                        "message": "Request timed out"
+                    }
+                }
+                response = Response(
+                    status_code=200,
+                    content=json.dumps(error_response),
+                    media_type="application/json",
+                    headers={"X-Session-Id": session_id} if is_new_session else {},
+                )
+            
+            # Set session cookie for new sessions
+            if is_new_session:
+                response.set_cookie(
+                    key="mcp-session-id",
+                    value=session_id,
+                    httponly=True,
+                    samesite="lax",
+                    max_age=86400  # 24 hours
+                )
+            
+            return response
+
+        except Exception as e:
+            logger.error(f"Error handling message for session {session_id}: {e}")
+            return Response(
+                status_code=500,
+                content=json.dumps({"error": "Internal server error"}),
+                media_type="application/json",
+            )
+
+    async def run(self):
+        """Run the proxy server.
+
+        This method starts the Uvicorn server with the configured settings.
+        """
+        config = uvicorn.Config(
+            self.app,
+            host=self.config.host,
+            port=self.config.port,
+            log_level="info",
+        )
+        server = uvicorn.Server(config)
+        await server.serve()
+
+    def run_sync(self):
+        """Run the proxy server synchronously.
+
+        This method is useful for running the server from a non-async context.
+        """
+        asyncio.run(self.run())

--- a/src/asyncmcp/proxy/session.py
+++ b/src/asyncmcp/proxy/session.py
@@ -1,0 +1,155 @@
+"""Proxy session implementation.
+
+This module contains the ProxySession class that represents a single
+proxy session maintaining a connection to the backend transport.
+"""
+
+import asyncio
+import logging
+from typing import Any, Dict, Optional, Union
+
+import anyio
+from anyio.abc import TaskGroup
+from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
+from mcp.shared.message import SessionMessage
+from mcp.types import ErrorData, JSONRPCMessage
+
+from .client import ProxyClient
+
+logger = logging.getLogger(__name__)
+
+
+class ProxySession:
+    """Represents a single proxy session.
+
+    Each session maintains a connection to the backend transport and
+    manages message routing between the client and backend.
+    """
+
+    def __init__(
+        self,
+        session_id: str,
+        backend_client: ProxyClient,
+        response_sender: MemoryObjectSendStream[SessionMessage],
+    ):
+        """Initialize a proxy session.
+
+        Args:
+            session_id: Unique session identifier
+            backend_client: Client for connecting to backend transport
+            response_sender: Stream for sending responses to the client
+        """
+        self.session_id = session_id
+        self.backend_client = backend_client
+        self.response_sender = response_sender
+
+        self._task_group: Optional[TaskGroup] = None
+        self._read_stream: Optional[MemoryObjectReceiveStream[Union[SessionMessage, Exception]]] = None
+        self._write_stream: Optional[MemoryObjectSendStream[SessionMessage]] = None
+        self._running = False
+        self._connected_event = anyio.Event()
+
+    async def start(self):
+        """Start the proxy session."""
+        if self._running:
+            return
+
+        self._running = True
+
+        async with anyio.create_task_group() as tg:
+            self._task_group = tg
+
+            try:
+                async with self.backend_client.connect() as (read_stream, write_stream):
+                    self._read_stream = read_stream
+                    self._write_stream = write_stream
+
+                    # Signal that we're connected
+                    self._connected_event.set()
+
+                    tg.start_soon(self._forward_responses)
+
+                    # Keep session alive until cancelled
+                    try:
+                        await anyio.Event().wait()
+                    except asyncio.CancelledError:
+                        logger.info(f"Proxy session {self.session_id} cancelled")
+                        raise
+            except Exception as e:
+                logger.error(f"Failed to connect to backend for session {self.session_id}: {type(e).__name__}: {e}")
+                raise
+
+    async def stop(self):
+        """Stop the proxy session."""
+        if not self._running:
+            return
+
+        self._running = False
+
+        if self._task_group:
+            self._task_group.cancel_scope.cancel()
+
+    async def send_message(self, message_data: Dict[str, Any]):
+        """Send a message to the backend.
+
+        Args:
+            message_data: JSON-RPC message data to send
+        """
+        logger.info(
+            f"Session {self.session_id} sending message: "
+            f"method={message_data.get('method', 'unknown')}, "
+            f"id={message_data.get('id', 'none')}"
+        )
+
+        # Wait for connection to be established
+        await self._connected_event.wait()
+
+        if not self._write_stream:
+            logger.error(f"Write stream is None for session {self.session_id}")
+            raise RuntimeError("Session not connected")
+
+        try:
+            # Parse and validate message
+            jsonrpc_message = JSONRPCMessage.model_validate(message_data)
+            session_message = SessionMessage(jsonrpc_message)
+
+            await self._write_stream.send(session_message)
+
+        except Exception as e:
+            logger.error(f"Session {self.session_id}: Error sending message: {e}")
+            raise
+
+    async def _forward_responses(self):
+        """Forward responses from backend to client."""
+        if not self._read_stream:
+            return
+
+        try:
+            async for message in self._read_stream:
+                if isinstance(message, Exception):
+                    # Handle backend errors
+                    logger.error(f"Backend error for session {self.session_id}: {message}")
+                    error_response = self._create_error_response(str(message))
+                    await self.response_sender.send(error_response)
+                else:
+                    # Forward response to client
+                    await self.response_sender.send(message)
+
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error(f"Session {self.session_id}: Error forwarding responses: {e}")
+
+    def _create_error_response(self, error_message: str) -> SessionMessage:
+        """Create an error response message."""
+        error_data = ErrorData(
+            code=-32603,  # Internal error
+            message=error_message,
+        )
+        jsonrpc_message = JSONRPCMessage.model_validate(
+            {
+                "jsonrpc": "2.0",
+                "error": error_data.model_dump(),
+            }
+        )
+        return SessionMessage(jsonrpc_message)

--- a/src/asyncmcp/proxy/session_manager.py
+++ b/src/asyncmcp/proxy/session_manager.py
@@ -6,170 +6,19 @@ StreamableHTTP frontend and asyncmcp backend transports.
 
 import asyncio
 import logging
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, cast
 
 import anyio
 from anyio.abc import TaskGroup
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from mcp.shared.message import SessionMessage
-from mcp.types import ErrorData, JSONRPCMessage
 
-from .client import ProxyClient, create_backend_client
+from .client import create_backend_client
+from .interceptor import InterceptingStream
+from .session import ProxySession
 from .utils import ProxyConfig, generate_session_id
 
 logger = logging.getLogger(__name__)
-
-
-class ProxySession:
-    """Represents a single proxy session.
-
-    Each session maintains a connection to the backend transport and
-    manages message routing between the client and backend.
-    """
-
-    def __init__(
-        self,
-        session_id: str,
-        backend_client: ProxyClient,
-        response_sender: MemoryObjectSendStream[SessionMessage],
-    ):
-        """Initialize a proxy session.
-
-        Args:
-            session_id: Unique session identifier
-            backend_client: Client for connecting to backend transport
-            response_sender: Stream for sending responses to the client
-        """
-        self.session_id = session_id
-        self.backend_client = backend_client
-        self.response_sender = response_sender
-
-        self._task_group: Optional[TaskGroup] = None
-        self._read_stream: Optional[MemoryObjectReceiveStream[Union[SessionMessage, Exception]]] = None
-        self._write_stream: Optional[MemoryObjectSendStream[SessionMessage]] = None
-        self._running = False
-        self._connected_event = anyio.Event()
-
-    async def start(self):
-        """Start the proxy session."""
-        if self._running:
-            return
-
-        self._running = True
-        logger.info(f"Starting proxy session {self.session_id}")
-
-        async with anyio.create_task_group() as tg:
-            self._task_group = tg
-
-            # Connect to backend
-            logger.info(f"Connecting to backend for session {self.session_id}")
-            try:
-                async with self.backend_client.connect() as (read_stream, write_stream):
-                    self._read_stream = read_stream
-                    self._write_stream = write_stream
-                    logger.info(f"Backend connected successfully for session {self.session_id}")
-                    logger.info(f"Read stream: {type(read_stream)}, Write stream: {type(write_stream)}")
-                    
-                    # Signal that we're connected
-                    self._connected_event.set()
-
-                    # Start forwarding messages from backend to client
-                    tg.start_soon(self._forward_responses)
-
-                    # Keep session alive until cancelled
-                    try:
-                        await anyio.Event().wait()
-                    except asyncio.CancelledError:
-                        logger.info(f"Proxy session {self.session_id} cancelled")
-                        raise
-            except Exception as e:
-                logger.error(f"Failed to connect to backend for session {self.session_id}: {type(e).__name__}: {e}")
-                import traceback
-                logger.error(f"Traceback: {traceback.format_exc()}")
-                raise
-
-    async def stop(self):
-        """Stop the proxy session."""
-        if not self._running:
-            return
-
-        self._running = False
-        logger.info(f"Stopping proxy session {self.session_id}")
-
-        if self._task_group:
-            self._task_group.cancel_scope.cancel()
-
-    async def send_message(self, message_data: Dict[str, Any]):
-        """Send a message to the backend.
-
-        Args:
-            message_data: JSON-RPC message data to send
-        """
-        logger.info(f"Session {self.session_id} sending message: method={message_data.get('method', 'unknown')}, id={message_data.get('id', 'none')}")
-        
-        # Wait for connection to be established
-        logger.debug(f"Waiting for connection event for session {self.session_id}...")
-        await self._connected_event.wait()
-        logger.debug(f"Connection event received for session {self.session_id}")
-        
-        if not self._write_stream:
-            logger.error(f"Write stream is None for session {self.session_id}")
-            raise RuntimeError("Session not connected")
-
-        try:
-            # Parse and validate message
-            logger.debug(f"Parsing message data: {message_data}")
-            jsonrpc_message = JSONRPCMessage.model_validate(message_data)
-            session_message = SessionMessage(jsonrpc_message)
-            logger.debug(f"Created SessionMessage: {session_message}")
-
-            # Send to backend
-            logger.info(f"Sending message to backend via write stream for session {self.session_id}")
-            await self._write_stream.send(session_message)
-            logger.info(f"Message sent successfully to backend for session {self.session_id}")
-
-        except Exception as e:
-            logger.error(f"Session {self.session_id}: Error sending message: {e}")
-            raise
-
-    async def _forward_responses(self):
-        """Forward responses from backend to client."""
-        if not self._read_stream:
-            return
-
-        logger.info(f"Starting response forwarding for session {self.session_id}")
-        try:
-            async for message in self._read_stream:
-                logger.info(f"Received message from backend for session {self.session_id}: {type(message)}")
-                if isinstance(message, Exception):
-                    # Handle backend errors
-                    logger.error(f"Backend error for session {self.session_id}: {message}")
-                    error_response = self._create_error_response(str(message))
-                    await self.response_sender.send(error_response)
-                else:
-                    # Forward response to client
-                    logger.info(f"Forwarding response to client for session {self.session_id}")
-                    await self.response_sender.send(message)
-                    logger.info(f"Session {self.session_id}: Successfully forwarded response to client")
-
-        except asyncio.CancelledError:
-            raise
-        except Exception as e:
-            logger.error(f"Session {self.session_id}: Error forwarding responses: {e}")
-
-    def _create_error_response(self, error_message: str) -> SessionMessage:
-        """Create an error response message."""
-        error_data = ErrorData(
-            code=-32603,  # Internal error
-            message=error_message,
-        )
-        jsonrpc_message = JSONRPCMessage.model_validate(
-            {
-                "jsonrpc": "2.0",
-                "error": error_data.model_dump(),
-            }
-        )
-        return SessionMessage(jsonrpc_message)
 
 
 class ProxySessionManager:
@@ -192,7 +41,7 @@ class ProxySessionManager:
         self._task_group: Optional[TaskGroup] = None
         self._running = False
         # Track pending responses for synchronous request/response pattern
-        self._pending_responses: Dict[str, asyncio.Future] = {}
+        self._pending_responses: Dict[str, asyncio.Future[str]] = {}
 
     @property
     def active_session_count(self) -> int:
@@ -213,13 +62,13 @@ class ProxySessionManager:
             bool: True if session exists
         """
         return session_id in self._sessions
-    
+
     def get_single_session_id(self) -> Optional[str]:
         """Get the session ID if there's only one active session.
-        
+
         This is used to support clients like MCP Inspector that expect
         a single session per server instance.
-        
+
         Returns:
             str: The session ID if there's exactly one session, None otherwise
         """
@@ -233,7 +82,6 @@ class ProxySessionManager:
             return
 
         self._running = True
-        logger.info("Starting proxy session manager")
 
     async def stop(self):
         """Stop the session manager and clean up all sessions."""
@@ -241,7 +89,6 @@ class ProxySessionManager:
             return
 
         self._running = False
-        logger.info("Stopping proxy session manager")
 
         # Stop all sessions
         for session_id in list(self._sessions.keys()):
@@ -276,14 +123,14 @@ class ProxySessionManager:
 
         await session.send_message(message_data)
 
-    async def wait_for_response(self, session_id: str, request_id: Any, timeout: float = 10.0) -> Optional[str]:
+    async def wait_for_response(self, session_id: str, request_id: Any, timeout: float = 60.0) -> Optional[str]:
         """Wait for a specific response from the backend.
-        
+
         Args:
             session_id: Session ID
             request_id: Request ID to wait for
             timeout: Maximum time to wait in seconds
-            
+
         Returns:
             JSON string of the response, or None if timeout
         """
@@ -291,7 +138,7 @@ class ProxySessionManager:
         future_key = f"{session_id}:{request_id}"
         future = asyncio.get_event_loop().create_future()
         self._pending_responses[future_key] = future
-        
+
         try:
             # Wait for the response with timeout
             response = await asyncio.wait_for(future, timeout=timeout)
@@ -305,25 +152,25 @@ class ProxySessionManager:
         finally:
             # Clean up the future
             self._pending_responses.pop(future_key, None)
-            
+
     def _handle_response(self, session_id: str, message: SessionMessage) -> bool:
         """Handle a response from the backend, checking for pending requests.
-        
+
         Args:
             session_id: Session ID
             message: Response message
-            
+
         Returns:
             True if message should be forwarded to SSE, False if handled synchronously
         """
         # Check if this is a response to a pending request
         message_dict = message.message.model_dump(exclude_none=True, by_alias=True)
         request_id = message_dict.get("id")
-        
+
         if request_id is not None:  # Changed from if request_id to handle id=0
             future_key = f"{session_id}:{request_id}"
             future = self._pending_responses.get(future_key)
-            
+
             if future and not future.done():
                 # Fulfill the pending request
                 response_json = message.message.model_dump_json(
@@ -331,41 +178,25 @@ class ProxySessionManager:
                     by_alias=True,
                 )
                 future.set_result(response_json)
-                logger.info(f"Fulfilled pending response for request {request_id}")
                 # Don't forward to SSE since it was handled synchronously
                 return False
-                
+
         # Forward to SSE stream
         return True
-        
-    def _create_intercepting_stream(self, session_id: str, original_stream: MemoryObjectSendStream[SessionMessage]) -> MemoryObjectSendStream[SessionMessage]:
+
+    def _create_intercepting_stream(
+        self, session_id: str, original_stream: MemoryObjectSendStream[SessionMessage]
+    ) -> MemoryObjectSendStream[SessionMessage]:
         """Create a wrapper stream that intercepts responses.
-        
+
         Args:
             session_id: Session ID
             original_stream: Original send stream
-            
+
         Returns:
             Wrapped stream that intercepts messages
         """
-        class InterceptingStream:
-            def __init__(self, manager, session_id, stream):
-                self.manager = manager
-                self.session_id = session_id
-                self.stream = stream
-                
-            async def send(self, message: SessionMessage):
-                # Check if this message should be handled synchronously
-                should_forward = self.manager._handle_response(self.session_id, message)
-                if should_forward:
-                    # Forward to SSE
-                    await self.stream.send(message)
-                # Otherwise it was handled by a pending request
-                
-            async def aclose(self):
-                await self.stream.aclose()
-                
-        return InterceptingStream(self, session_id, original_stream)
+        return cast(MemoryObjectSendStream[SessionMessage], InterceptingStream(self, session_id, original_stream))
 
     async def remove_session(self, session_id: str):
         """Remove a session and clean up its resources.
@@ -386,8 +217,6 @@ class ProxySessionManager:
         if receiver:
             await receiver.aclose()
 
-        logger.info(f"Removed session {session_id}")
-
     async def _create_session(self, session_id: str):
         """Create a new proxy session.
 
@@ -401,28 +230,22 @@ class ProxySessionManager:
         if len(self._sessions) >= self.config.max_sessions:
             raise RuntimeError(f"Maximum session limit ({self.config.max_sessions}) reached")
 
-        logger.info(f"Creating proxy session {session_id}")
-
         # Create response streams
         send_stream, receive_stream = anyio.create_memory_object_stream[SessionMessage](100)
         self._response_streams[session_id] = send_stream
         self._response_receivers[session_id] = receive_stream
 
         # Create backend client
-        logger.info(f"Creating backend client for transport: {self.config.backend_transport}")
-        logger.info(f"Backend config: {self.config.backend_config}")
-        logger.info(f"Backend clients: {self.config.backend_clients}")
         backend_client = create_backend_client(
             transport_type=self.config.backend_transport,
             config=self.config.backend_config,  # type: ignore[arg-type]
             low_level_clients=self.config.backend_clients,
             session_id=session_id,
         )
-        logger.info(f"Backend client created: {type(backend_client).__name__} for session {session_id}")
 
         # Create a wrapper send stream that intercepts responses
         wrapped_send_stream = self._create_intercepting_stream(session_id, send_stream)
-        
+
         # Create and start session
         session = ProxySession(
             session_id=session_id,

--- a/src/asyncmcp/proxy/session_resolver.py
+++ b/src/asyncmcp/proxy/session_resolver.py
@@ -1,0 +1,146 @@
+"""Session resolution logic for proxy server.
+
+This module handles the complex logic of resolving session IDs from
+various sources including headers, cookies, and request context.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Protocol
+
+from starlette.requests import Request
+
+logger = logging.getLogger(__name__)
+
+
+class SessionManagerProtocol(Protocol):
+    """Protocol for session manager."""
+
+    @property
+    def active_session_count(self) -> int:
+        """Get the number of active sessions."""
+        ...
+
+    def create_session_id(self) -> str:
+        """Create a new session ID."""
+        ...
+
+    def get_single_session_id(self) -> Optional[str]:
+        """Get the single session ID if only one exists."""
+        ...
+
+    def has_session(self, session_id: str) -> bool:
+        """Check if a session exists."""
+        ...
+
+
+@dataclass
+class SessionResolution:
+    """Result of session resolution."""
+
+    session_id: Optional[str]
+    is_new_session: bool
+    error_message: Optional[str] = None
+
+
+class SessionResolver:
+    """Handles session resolution from various sources.
+
+    This class encapsulates the complex logic of determining which
+    session to use based on headers, cookies, initialization state,
+    and configuration.
+    """
+
+    def __init__(self, session_manager: SessionManagerProtocol, stateless: bool = False):
+        """Initialize the session resolver.
+
+        Args:
+            session_manager: The session manager to use
+            stateless: Whether to run in stateless mode
+        """
+        self.session_manager = session_manager
+        self.stateless = stateless
+
+    async def resolve_session(
+        self,
+        request: Request,
+        message_data: Dict[str, Any],
+    ) -> SessionResolution:
+        """Resolve the session ID from various sources.
+
+        Args:
+            request: The HTTP request
+            message_data: The parsed message data
+            debug_logging: Whether to log debug information
+
+        Returns:
+            SessionResolution with the session ID and metadata
+        """
+        is_initialize = message_data.get("method") == "initialize"
+
+        # 1. Check X-Session-Id header (for clients that support it)
+        session_id = request.headers.get("X-Session-Id")
+        if session_id:
+            logger.debug(f"Found session ID in X-Session-Id header: {session_id}")
+            return SessionResolution(session_id, False)
+
+        # 2. Check cookies for session (for browser-based clients like MCP Inspector)
+        if "cookie" in request.headers:
+            cookies = request.cookies
+            session_id = cookies.get("mcp-session-id")
+            if session_id:
+                logger.debug(f"Found session ID in cookie: {session_id}")
+                return SessionResolution(session_id, False)
+
+        # 3. For stateless mode or single session, use a default session
+        if self.stateless or is_initialize:
+            # In stateless mode or for initialize, use/create a default session
+            if self.stateless:
+                session_id = "default"
+                logger.debug("Using default session for stateless mode")
+                return SessionResolution(session_id, False)
+            elif is_initialize:
+                # For initialize, try to use existing session if there's only one
+                if self.session_manager.active_session_count == 1:
+                    session_id = self.session_manager.get_single_session_id()
+                    logger.info(f"Using existing single session for initialize: {session_id}")
+                    return SessionResolution(session_id, False)
+                else:
+                    # Create new session for initialize requests
+                    session_id = self.session_manager.create_session_id()
+                    logger.info(f"New session created for initialize request: {session_id}")
+                    return SessionResolution(session_id, True)
+
+        # 4. If still no session ID and not initialize, try to get the first/only active session
+        # This supports MCP Inspector which expects a single session per server
+        if self.session_manager.active_session_count == 1:
+            # Get the single active session
+            session_id = self.session_manager.get_single_session_id()
+            if session_id:
+                return SessionResolution(session_id, False)
+
+        # 5. Final check - if no session ID found, return error
+        logger.error(f"No session ID found. Active sessions: {self.session_manager.active_session_count}")
+        return SessionResolution(None, False, "No active session. Please initialize first.")
+
+    def resolve_sse_session(self, request: Request) -> tuple[str, bool]:
+        """Resolve session for SSE connections.
+
+        Args:
+            request: The HTTP request
+
+        Returns:
+            Tuple of (session_id, is_new_session)
+        """
+        # Check for existing session ID
+        session_id = request.headers.get("X-Session-Id")
+        if not session_id:
+            # Create new session for SSE
+            session_id = self.session_manager.create_session_id()
+            client_host = request.client.host if request.client else "unknown"
+            logger.info(f"New SSE connection from {client_host}, assigned session {session_id}")
+            return session_id, True
+        else:
+            client_host = request.client.host if request.client else "unknown"
+            logger.info(f"Existing SSE connection from {client_host}, session {session_id}")
+            return session_id, False

--- a/src/asyncmcp/proxy/sse_handler.py
+++ b/src/asyncmcp/proxy/sse_handler.py
@@ -1,0 +1,106 @@
+"""Server-Sent Events (SSE) handling for proxy server.
+
+This module handles SSE connections and streaming responses.
+"""
+
+import asyncio
+import json
+import logging
+from typing import AsyncGenerator, Protocol
+
+from anyio.streams.memory import MemoryObjectReceiveStream
+from mcp.shared.message import SessionMessage
+from starlette.responses import StreamingResponse
+
+logger = logging.getLogger(__name__)
+
+
+class SessionManagerProtocol(Protocol):
+    """Protocol for session manager."""
+
+    async def get_response_stream(self, session_id: str) -> MemoryObjectReceiveStream[SessionMessage]:
+        """Get the response stream for a session."""
+        ...
+
+
+class SSEHandler:
+    """Handles Server-Sent Events (SSE) connections.
+
+    This class encapsulates the logic for creating SSE responses
+    and streaming messages from the backend.
+    """
+
+    def __init__(self, session_manager: SessionManagerProtocol):
+        """Initialize the SSE handler.
+
+        Args:
+            session_manager: The session manager to use
+        """
+        self.session_manager = session_manager
+
+    async def create_sse_response(self, session_id: str, is_new_session: bool = False) -> StreamingResponse:
+        """Create an SSE response for a session.
+
+        Args:
+            session_id: The session ID
+            is_new_session: Whether this is a new session
+
+        Returns:
+            StreamingResponse for SSE
+        """
+        response = StreamingResponse(
+            self._event_generator(session_id),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "X-Session-Id": session_id,
+            },
+        )
+
+        # Set session cookie for browser-based clients
+        response.set_cookie(
+            key="mcp-session-id",
+            value=session_id,
+            httponly=True,
+            samesite="lax",
+            max_age=86400,  # 24 hours
+        )
+
+        return response
+
+    async def _event_generator(self, session_id: str) -> AsyncGenerator[str, None]:
+        """Generate SSE events from backend responses.
+
+        Args:
+            session_id: The session ID
+
+        Yields:
+            SSE formatted events
+        """
+        try:
+            # Get response stream for this session
+            response_stream = await self.session_manager.get_response_stream(session_id)
+
+            # Stream responses from backend
+            async for message in response_stream:
+                # Convert SessionMessage to JSON
+                message_data = message.message.model_dump_json(
+                    exclude_none=True,
+                    by_alias=True,
+                )
+
+                # Send as SSE event
+                yield f"event: message\ndata: {message_data}\n\n"
+
+        except asyncio.CancelledError:
+            logger.info(f"SSE connection closed for session {session_id}")
+            raise
+        except Exception as e:
+            logger.error(f"Error in SSE stream for session {session_id}: {e}")
+            error_data = json.dumps({"error": str(e), "type": "stream_error"})
+            yield f"event: error\ndata: {error_data}\n\n"
+        finally:
+            # Don't remove session here - sessions should persist beyond SSE connections
+            # This allows clients like MCP Inspector to reconnect or make subsequent requests
+            logger.info(f"SSE stream ended for session {session_id}, but session remains active")

--- a/src/asyncmcp/proxy/utils.py
+++ b/src/asyncmcp/proxy/utils.py
@@ -1,0 +1,176 @@
+"""Proxy utilities and configuration.
+
+This module provides configuration classes and utility functions for the
+asyncmcp proxy server.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Union
+
+if TYPE_CHECKING:
+    from .server import ProxyServer
+
+from asyncmcp.sns_sqs.utils import SnsSqsClientConfig
+from asyncmcp.sqs.utils import SqsClientConfig
+from asyncmcp.streamable_http_webhook.utils import StreamableHTTPWebhookClientConfig
+from asyncmcp.webhook.utils import WebhookClientConfig
+
+logger = logging.getLogger(__name__)
+
+# Supported backend transport types
+BackendTransportType = Literal["sqs", "sns_sqs", "webhook", "streamable_http_webhook"]
+
+# Union type for all backend configurations
+BackendConfig = Union[
+    SqsClientConfig,
+    SnsSqsClientConfig,
+    WebhookClientConfig,
+    StreamableHTTPWebhookClientConfig,
+]
+
+
+@dataclass
+class ProxyConfig:
+    """Configuration for the asyncmcp proxy server.
+
+    The proxy server exposes a StreamableHTTP endpoint that forwards
+    requests to a configured asyncmcp backend transport.
+    """
+
+    # Server settings
+    host: str = "127.0.0.1"
+    port: int = 8080
+    server_path: str = "/mcp"
+
+    # Backend transport settings
+    backend_transport: BackendTransportType = "sqs"
+    backend_config: Optional[BackendConfig] = None
+    backend_clients: Dict[str, Any] = field(default_factory=lambda: {})
+
+    # Session management
+    session_timeout: float = 300.0  # 5 minutes
+    max_sessions: int = 100
+    stateless: bool = False
+
+    # Performance settings
+    connection_pool_size: int = 10
+    request_timeout: float = 30.0
+
+    # Security settings
+    cors_origins: Optional[list[str]] = None
+    auth_enabled: bool = False
+    auth_token: Optional[str] = None
+
+    def __post_init__(self):
+        """Validate configuration after initialization."""
+        if self.backend_config is None:
+            raise ValueError("backend_config is required")
+
+        # Validate backend transport type matches config type
+        config_type_map = {
+            "sqs": SqsClientConfig,
+            "sns_sqs": SnsSqsClientConfig,
+            "webhook": WebhookClientConfig,
+            "streamable_http_webhook": StreamableHTTPWebhookClientConfig,
+        }
+
+        expected_type = config_type_map.get(self.backend_transport)
+        if expected_type and not isinstance(self.backend_config, expected_type):  # type: ignore[arg-type]
+            raise ValueError(
+                f"backend_config must be {expected_type.__name__} for transport type '{self.backend_transport}'"
+            )
+
+
+def create_proxy_server(
+    backend_transport: BackendTransportType,
+    backend_config: BackendConfig,
+    backend_clients: Optional[Dict[str, Any]] = None,
+    host: str = "127.0.0.1",
+    port: int = 8080,
+    server_path: str = "/mcp",
+    **kwargs: Any,
+) -> "ProxyServer":
+    """Create a proxy server with the specified configuration.
+
+    This is a convenience function for creating a proxy server with
+    common settings.
+
+    Args:
+        backend_transport: The type of backend transport to use
+        backend_config: Configuration for the backend transport
+        backend_clients: Low-level clients (e.g., boto3) for the backend
+        host: Host to bind the proxy server to
+        port: Port to bind the proxy server to
+        server_path: HTTP path for the MCP endpoint
+        **kwargs: Additional configuration options
+
+    Returns:
+        ProxyServer: Configured proxy server instance
+
+    Example:
+        ```python
+        from asyncmcp.proxy import create_proxy_server
+        from asyncmcp.sqs.utils import SqsClientConfig
+        import boto3
+
+        # Create SQS backend config
+        backend_config = SqsClientConfig(
+            read_queue_url="https://sqs.us-east-1.amazonaws.com/123/requests",
+            response_queue_url="https://sqs.us-east-1.amazonaws.com/123/responses"
+        )
+
+        # Create proxy server
+        proxy = create_proxy_server(
+            backend_transport="sqs",
+            backend_config=backend_config,
+            backend_clients={"sqs_client": boto3.client("sqs")},
+            port=8080
+        )
+
+        # Run the server
+        await proxy.run()
+        ```
+    """
+    from .server import ProxyServer
+
+    config = ProxyConfig(
+        host=host,
+        port=port,
+        server_path=server_path,
+        backend_transport=backend_transport,
+        backend_config=backend_config,
+        backend_clients=backend_clients or {},
+        **kwargs,
+    )
+
+    return ProxyServer(config)
+
+
+def generate_session_id() -> str:
+    """Generate a unique session ID."""
+    import uuid
+
+    return str(uuid.uuid4())
+
+
+def validate_auth_token(token: Optional[str], expected_token: Optional[str]) -> bool:
+    """Validate an authentication token.
+
+    Args:
+        token: The token to validate
+        expected_token: The expected token value
+
+    Returns:
+        bool: True if the token is valid, False otherwise
+    """
+    if not expected_token:
+        # No auth required
+        return True
+
+    if not token:
+        # Auth required but no token provided
+        return False
+
+    # Simple token comparison (could be enhanced with JWT, etc.)
+    return token == expected_token

--- a/src/asyncmcp/proxy/utils.py
+++ b/src/asyncmcp/proxy/utils.py
@@ -55,7 +55,7 @@ class ProxyConfig:
 
     # Performance settings
     connection_pool_size: int = 10
-    request_timeout: float = 30.0
+    request_timeout: float = 180.0
 
     # Security settings
     cors_origins: Optional[list[str]] = None

--- a/tests/proxy/test_client.py
+++ b/tests/proxy/test_client.py
@@ -5,44 +5,43 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from asyncmcp.proxy.client import ProxyClient, create_backend_client
-from asyncmcp.sqs.utils import SqsClientConfig
 from asyncmcp.sns_sqs.utils import SnsSqsClientConfig
+from asyncmcp.sqs.utils import SqsClientConfig
 from asyncmcp.webhook.utils import WebhookClientConfig
-from asyncmcp.streamable_http_webhook.utils import StreamableHTTPWebhookClientConfig
 
 
 class TestProxyClient:
     """Test ProxyClient class."""
-    
+
     @pytest.fixture
     def mock_sqs_client(self):
         """Create a mock SQS client."""
         return MagicMock()
-        
+
     @pytest.fixture
     def mock_sns_client(self):
         """Create a mock SNS client."""
         return MagicMock()
-        
+
     def test_init(self):
         """Test ProxyClient initialization."""
         config = SqsClientConfig(
             read_queue_url="https://sqs.example.com/queue",
             response_queue_url="https://sqs.example.com/response",
         )
-        
+
         client = ProxyClient(
             transport_type="sqs",
             config=config,
             low_level_clients={"sqs_client": MagicMock()},
             session_id="test-session",
         )
-        
+
         assert client.transport_type == "sqs"
         assert client.config == config
         assert "sqs_client" in client.low_level_clients
         assert client.session_id == "test-session"
-        
+
     @pytest.mark.anyio
     async def test_connect_sqs(self, mock_sqs_client):
         """Test connecting to SQS backend."""
@@ -50,27 +49,27 @@ class TestProxyClient:
             read_queue_url="https://sqs.example.com/queue",
             response_queue_url="https://sqs.example.com/response",
         )
-        
+
         client = ProxyClient(
             transport_type="sqs",
             config=config,
             low_level_clients={"sqs_client": mock_sqs_client},
         )
-        
+
         # Mock the sqs_client context manager
         mock_streams = (AsyncMock(), AsyncMock())
         with patch("asyncmcp.proxy.client.sqs_client") as mock_sqs:
             mock_sqs.return_value.__aenter__.return_value = mock_streams
-            
+
             async with client.connect() as (read_stream, write_stream):
                 assert read_stream == mock_streams[0]
                 assert write_stream == mock_streams[1]
-                
+
             mock_sqs.assert_called_once_with(
                 config=config,
                 sqs_client=mock_sqs_client,
             )
-            
+
     @pytest.mark.anyio
     async def test_connect_sns_sqs(self, mock_sqs_client, mock_sns_client):
         """Test connecting to SNS+SQS backend."""
@@ -78,7 +77,7 @@ class TestProxyClient:
             sns_topic_arn="arn:aws:sns:us-east-1:123:topic",
             sqs_queue_url="https://sqs.example.com/queue",
         )
-        
+
         client = ProxyClient(
             transport_type="sns_sqs",
             config=config,
@@ -87,44 +86,44 @@ class TestProxyClient:
                 "sns_client": mock_sns_client,
             },
         )
-        
+
         # Mock the sns_sqs_client context manager
         mock_streams = (AsyncMock(), AsyncMock())
         with patch("asyncmcp.proxy.client.sns_sqs_client") as mock_sns_sqs:
             mock_sns_sqs.return_value.__aenter__.return_value = mock_streams
-            
+
             async with client.connect() as (read_stream, write_stream):
                 assert read_stream == mock_streams[0]
                 assert write_stream == mock_streams[1]
-                
+
             mock_sns_sqs.assert_called_once_with(
                 config=config,
                 sqs_client=mock_sqs_client,
                 sns_client=mock_sns_client,
                 client_topic_arn=config.sns_topic_arn,
             )
-            
+
     @pytest.mark.anyio
     async def test_connect_webhook(self):
         """Test connecting to Webhook backend."""
         config = WebhookClientConfig(server_url="http://example.com/mcp")
-        
+
         client = ProxyClient(
             transport_type="webhook",
             config=config,
         )
-        
+
         # Mock the webhook_client context manager
         mock_streams = (AsyncMock(), AsyncMock(), AsyncMock())  # 3-tuple
         with patch("asyncmcp.proxy.client.webhook_client") as mock_webhook:
             mock_webhook.return_value.__aenter__.return_value = mock_streams
-            
+
             async with client.connect() as (read_stream, write_stream):
                 assert read_stream == mock_streams[0]
                 assert write_stream == mock_streams[1]
-                
+
             mock_webhook.assert_called_once_with(config=config)
-            
+
     @pytest.mark.anyio
     async def test_connect_unsupported_transport(self):
         """Test connecting with unsupported transport type."""
@@ -135,11 +134,11 @@ class TestProxyClient:
                 response_queue_url="https://sqs.example.com/response",
             ),
         )
-        
+
         with pytest.raises(ValueError, match="Unsupported transport type"):
             async with client.connect():
                 pass
-                
+
     @pytest.mark.anyio
     async def test_connect_missing_client(self):
         """Test connecting without required low-level client."""
@@ -147,28 +146,28 @@ class TestProxyClient:
             read_queue_url="https://sqs.example.com/queue",
             response_queue_url="https://sqs.example.com/response",
         )
-        
+
         client = ProxyClient(
             transport_type="sqs",
             config=config,
             low_level_clients={},  # Missing sqs_client
         )
-        
+
         with pytest.raises(ValueError, match="SQS transport requires 'sqs_client'"):
             async with client.connect():
                 pass
-                
+
     @pytest.mark.anyio
     async def test_connect_wrong_config_type(self, mock_sqs_client):
         """Test connecting with wrong config type."""
         config = WebhookClientConfig(server_url="http://example.com")  # Wrong type for SQS
-        
+
         client = ProxyClient(
             transport_type="sqs",
             config=config,
             low_level_clients={"sqs_client": mock_sqs_client},
         )
-        
+
         with pytest.raises(TypeError, match="Expected SqsClientConfig"):
             async with client.connect():
                 pass
@@ -176,21 +175,21 @@ class TestProxyClient:
 
 class TestCreateBackendClient:
     """Test create_backend_client function."""
-    
+
     def test_create_backend_client(self):
         """Test creating a backend client."""
         config = SqsClientConfig(
             read_queue_url="https://sqs.example.com/queue",
             response_queue_url="https://sqs.example.com/response",
         )
-        
+
         client = create_backend_client(
             transport_type="sqs",
             config=config,
             low_level_clients={"sqs_client": MagicMock()},
             session_id="test-session",
         )
-        
+
         assert isinstance(client, ProxyClient)
         assert client.transport_type == "sqs"
         assert client.config == config

--- a/tests/proxy/test_client.py
+++ b/tests/proxy/test_client.py
@@ -1,0 +1,197 @@
+"""Tests for proxy client."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from asyncmcp.proxy.client import ProxyClient, create_backend_client
+from asyncmcp.sqs.utils import SqsClientConfig
+from asyncmcp.sns_sqs.utils import SnsSqsClientConfig
+from asyncmcp.webhook.utils import WebhookClientConfig
+from asyncmcp.streamable_http_webhook.utils import StreamableHTTPWebhookClientConfig
+
+
+class TestProxyClient:
+    """Test ProxyClient class."""
+    
+    @pytest.fixture
+    def mock_sqs_client(self):
+        """Create a mock SQS client."""
+        return MagicMock()
+        
+    @pytest.fixture
+    def mock_sns_client(self):
+        """Create a mock SNS client."""
+        return MagicMock()
+        
+    def test_init(self):
+        """Test ProxyClient initialization."""
+        config = SqsClientConfig(
+            read_queue_url="https://sqs.example.com/queue",
+            response_queue_url="https://sqs.example.com/response",
+        )
+        
+        client = ProxyClient(
+            transport_type="sqs",
+            config=config,
+            low_level_clients={"sqs_client": MagicMock()},
+            session_id="test-session",
+        )
+        
+        assert client.transport_type == "sqs"
+        assert client.config == config
+        assert "sqs_client" in client.low_level_clients
+        assert client.session_id == "test-session"
+        
+    @pytest.mark.anyio
+    async def test_connect_sqs(self, mock_sqs_client):
+        """Test connecting to SQS backend."""
+        config = SqsClientConfig(
+            read_queue_url="https://sqs.example.com/queue",
+            response_queue_url="https://sqs.example.com/response",
+        )
+        
+        client = ProxyClient(
+            transport_type="sqs",
+            config=config,
+            low_level_clients={"sqs_client": mock_sqs_client},
+        )
+        
+        # Mock the sqs_client context manager
+        mock_streams = (AsyncMock(), AsyncMock())
+        with patch("asyncmcp.proxy.client.sqs_client") as mock_sqs:
+            mock_sqs.return_value.__aenter__.return_value = mock_streams
+            
+            async with client.connect() as (read_stream, write_stream):
+                assert read_stream == mock_streams[0]
+                assert write_stream == mock_streams[1]
+                
+            mock_sqs.assert_called_once_with(
+                config=config,
+                sqs_client=mock_sqs_client,
+            )
+            
+    @pytest.mark.anyio
+    async def test_connect_sns_sqs(self, mock_sqs_client, mock_sns_client):
+        """Test connecting to SNS+SQS backend."""
+        config = SnsSqsClientConfig(
+            sns_topic_arn="arn:aws:sns:us-east-1:123:topic",
+            sqs_queue_url="https://sqs.example.com/queue",
+        )
+        
+        client = ProxyClient(
+            transport_type="sns_sqs",
+            config=config,
+            low_level_clients={
+                "sqs_client": mock_sqs_client,
+                "sns_client": mock_sns_client,
+            },
+        )
+        
+        # Mock the sns_sqs_client context manager
+        mock_streams = (AsyncMock(), AsyncMock())
+        with patch("asyncmcp.proxy.client.sns_sqs_client") as mock_sns_sqs:
+            mock_sns_sqs.return_value.__aenter__.return_value = mock_streams
+            
+            async with client.connect() as (read_stream, write_stream):
+                assert read_stream == mock_streams[0]
+                assert write_stream == mock_streams[1]
+                
+            mock_sns_sqs.assert_called_once_with(
+                config=config,
+                sqs_client=mock_sqs_client,
+                sns_client=mock_sns_client,
+                client_topic_arn=config.sns_topic_arn,
+            )
+            
+    @pytest.mark.anyio
+    async def test_connect_webhook(self):
+        """Test connecting to Webhook backend."""
+        config = WebhookClientConfig(server_url="http://example.com/mcp")
+        
+        client = ProxyClient(
+            transport_type="webhook",
+            config=config,
+        )
+        
+        # Mock the webhook_client context manager
+        mock_streams = (AsyncMock(), AsyncMock(), AsyncMock())  # 3-tuple
+        with patch("asyncmcp.proxy.client.webhook_client") as mock_webhook:
+            mock_webhook.return_value.__aenter__.return_value = mock_streams
+            
+            async with client.connect() as (read_stream, write_stream):
+                assert read_stream == mock_streams[0]
+                assert write_stream == mock_streams[1]
+                
+            mock_webhook.assert_called_once_with(config=config)
+            
+    @pytest.mark.anyio
+    async def test_connect_unsupported_transport(self):
+        """Test connecting with unsupported transport type."""
+        client = ProxyClient(
+            transport_type="unsupported",  # type: ignore
+            config=SqsClientConfig(
+                read_queue_url="https://sqs.example.com/queue",
+                response_queue_url="https://sqs.example.com/response",
+            ),
+        )
+        
+        with pytest.raises(ValueError, match="Unsupported transport type"):
+            async with client.connect():
+                pass
+                
+    @pytest.mark.anyio
+    async def test_connect_missing_client(self):
+        """Test connecting without required low-level client."""
+        config = SqsClientConfig(
+            read_queue_url="https://sqs.example.com/queue",
+            response_queue_url="https://sqs.example.com/response",
+        )
+        
+        client = ProxyClient(
+            transport_type="sqs",
+            config=config,
+            low_level_clients={},  # Missing sqs_client
+        )
+        
+        with pytest.raises(ValueError, match="SQS transport requires 'sqs_client'"):
+            async with client.connect():
+                pass
+                
+    @pytest.mark.anyio
+    async def test_connect_wrong_config_type(self, mock_sqs_client):
+        """Test connecting with wrong config type."""
+        config = WebhookClientConfig(server_url="http://example.com")  # Wrong type for SQS
+        
+        client = ProxyClient(
+            transport_type="sqs",
+            config=config,
+            low_level_clients={"sqs_client": mock_sqs_client},
+        )
+        
+        with pytest.raises(TypeError, match="Expected SqsClientConfig"):
+            async with client.connect():
+                pass
+
+
+class TestCreateBackendClient:
+    """Test create_backend_client function."""
+    
+    def test_create_backend_client(self):
+        """Test creating a backend client."""
+        config = SqsClientConfig(
+            read_queue_url="https://sqs.example.com/queue",
+            response_queue_url="https://sqs.example.com/response",
+        )
+        
+        client = create_backend_client(
+            transport_type="sqs",
+            config=config,
+            low_level_clients={"sqs_client": MagicMock()},
+            session_id="test-session",
+        )
+        
+        assert isinstance(client, ProxyClient)
+        assert client.transport_type == "sqs"
+        assert client.config == config
+        assert client.session_id == "test-session"

--- a/tests/proxy/test_integration.py
+++ b/tests/proxy/test_integration.py
@@ -1,0 +1,186 @@
+"""Integration tests for proxy functionality."""
+
+import asyncio
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from mcp.shared.message import SessionMessage
+from mcp.types import JSONRPCMessage
+
+from asyncmcp.proxy import ProxyConfig, ProxySessionManager
+from asyncmcp.proxy.client import ProxyClient
+from asyncmcp.sqs.utils import SqsClientConfig
+
+
+class TestProxyIntegration:
+    """Integration tests for proxy server functionality."""
+
+    @pytest.fixture
+    def mock_sqs_client(self):
+        """Create a mock SQS client."""
+        return MagicMock()
+
+    @pytest.fixture
+    def proxy_config(self, mock_sqs_client):
+        """Create proxy configuration."""
+        backend_config = SqsClientConfig(
+            read_queue_url="https://sqs.example.com/queue",
+            response_queue_url="https://sqs.example.com/response",
+        )
+
+        return ProxyConfig(
+            backend_transport="sqs",
+            backend_config=backend_config,
+            backend_clients={"sqs_client": mock_sqs_client},
+            host="127.0.0.1",
+            port=8080,
+            max_sessions=10,
+        )
+
+    @pytest.mark.anyio
+    async def test_session_creation_and_message_flow(self, proxy_config):
+        """Test basic session creation and message flow."""
+        # Create session manager
+        manager = ProxySessionManager(proxy_config)
+
+        # Start manager
+        await manager.start()
+
+        try:
+            # Create a session
+            session_id = manager.create_session_id()
+            assert not manager.has_session(session_id)
+
+            # Get response stream creates session
+            response_stream = await manager.get_response_stream(session_id)
+            assert manager.has_session(session_id)
+            assert manager.active_session_count == 1
+
+            # Test session ID management
+            assert manager.get_single_session_id() == session_id
+
+        finally:
+            await manager.stop()
+            assert manager.active_session_count == 0
+
+    @pytest.mark.anyio
+    async def test_message_routing(self, proxy_config):
+        """Test message routing through proxy."""
+        manager = ProxySessionManager(proxy_config)
+        await manager.start()
+
+        try:
+            # Create session
+            session_id = manager.create_session_id()
+            response_stream = await manager.get_response_stream(session_id)
+
+            # Mock backend client behavior
+            mock_client = ProxyClient(
+                transport_type="sqs",
+                config=proxy_config.backend_config,
+                low_level_clients=proxy_config.backend_clients,
+                session_id=session_id,
+            )
+
+            # Test sending message (would fail in real scenario without proper mocking)
+            message_data = {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
+
+            # This would normally send to backend
+            # For now just verify session exists
+            assert manager.has_session(session_id)
+
+        finally:
+            await manager.stop()
+
+    @pytest.mark.anyio
+    async def test_multiple_sessions(self, proxy_config):
+        """Test handling multiple sessions."""
+        manager = ProxySessionManager(proxy_config)
+        await manager.start()
+
+        try:
+            # Create multiple sessions
+            session_ids = []
+            for i in range(3):
+                session_id = manager.create_session_id()
+                await manager.get_response_stream(session_id)
+                session_ids.append(session_id)
+
+            assert manager.active_session_count == 3
+
+            # With multiple sessions, get_single_session_id returns None
+            assert manager.get_single_session_id() is None
+
+            # Remove a session
+            await manager.remove_session(session_ids[0])
+            assert manager.active_session_count == 2
+            assert not manager.has_session(session_ids[0])
+
+        finally:
+            await manager.stop()
+
+    @pytest.mark.anyio
+    async def test_session_limit(self, proxy_config):
+        """Test session limit enforcement."""
+        proxy_config.max_sessions = 2
+        manager = ProxySessionManager(proxy_config)
+        await manager.start()
+
+        try:
+            # Create max sessions
+            session1 = manager.create_session_id()
+            await manager.get_response_stream(session1)
+
+            session2 = manager.create_session_id()
+            await manager.get_response_stream(session2)
+
+            assert manager.active_session_count == 2
+
+            # Try to create one more
+            session3 = manager.create_session_id()
+            with pytest.raises(RuntimeError, match="Maximum session limit"):
+                await manager.get_response_stream(session3)
+
+        finally:
+            await manager.stop()
+
+    @pytest.mark.anyio
+    async def test_wait_for_response(self, proxy_config):
+        """Test synchronous response waiting."""
+        manager = ProxySessionManager(proxy_config)
+        await manager.start()
+
+        try:
+            session_id = manager.create_session_id()
+            await manager.get_response_stream(session_id)
+
+            # Start waiting for response
+            request_id = 123
+            wait_task = asyncio.create_task(manager.wait_for_response(session_id, request_id, timeout=1.0))
+
+            # Give the task a moment to register the pending response
+            await asyncio.sleep(0.1)
+
+            # Simulate response
+            message = SessionMessage(
+                JSONRPCMessage.model_validate(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "result": {"tools": []},
+                    }
+                )
+            )
+
+            # Handle response
+            should_forward = manager._handle_response(session_id, message)
+            assert not should_forward  # Should be handled synchronously
+
+            # Wait should complete
+            response = await wait_task
+            assert response is not None
+            assert json.loads(response)["id"] == request_id
+
+        finally:
+            await manager.stop()

--- a/tests/proxy/test_utils.py
+++ b/tests/proxy/test_utils.py
@@ -1,0 +1,112 @@
+"""Tests for proxy utilities and configuration."""
+
+import pytest
+
+from asyncmcp.proxy.utils import (
+    ProxyConfig,
+    generate_session_id,
+    validate_auth_token,
+)
+from asyncmcp.sqs.utils import SqsClientConfig
+from asyncmcp.sns_sqs.utils import SnsSqsClientConfig
+from asyncmcp.webhook.utils import WebhookClientConfig
+
+
+class TestProxyConfig:
+    """Test ProxyConfig class."""
+    
+    def test_default_config(self):
+        """Test default configuration values."""
+        config = ProxyConfig(
+            backend_config=SqsClientConfig(
+                read_queue_url="https://sqs.example.com/queue",
+                response_queue_url="https://sqs.example.com/response",
+            )
+        )
+        
+        assert config.host == "127.0.0.1"
+        assert config.port == 8080
+        assert config.server_path == "/mcp"
+        assert config.backend_transport == "sqs"
+        assert config.session_timeout == 300.0
+        assert config.max_sessions == 100
+        assert config.stateless is False
+        
+    def test_config_validation(self):
+        """Test configuration validation."""
+        # Missing backend_config
+        with pytest.raises(ValueError, match="backend_config is required"):
+            ProxyConfig()
+            
+        # Mismatched transport type and config
+        with pytest.raises(ValueError, match="backend_config must be SqsClientConfig"):
+            ProxyConfig(
+                backend_transport="sqs",
+                backend_config=WebhookClientConfig(server_url="http://example.com"),
+            )
+            
+    def test_custom_config(self):
+        """Test custom configuration values."""
+        backend_config = SnsSqsClientConfig(
+            sns_topic_arn="arn:aws:sns:us-east-1:123:topic",
+            sqs_queue_url="https://sqs.example.com/queue",
+        )
+        
+        config = ProxyConfig(
+            host="0.0.0.0",
+            port=9090,
+            server_path="/proxy",
+            backend_transport="sns_sqs",
+            backend_config=backend_config,
+            session_timeout=600.0,
+            max_sessions=50,
+            stateless=True,
+            cors_origins=["http://localhost:3000"],
+            auth_enabled=True,
+            auth_token="secret-token",
+        )
+        
+        assert config.host == "0.0.0.0"
+        assert config.port == 9090
+        assert config.server_path == "/proxy"
+        assert config.backend_transport == "sns_sqs"
+        assert config.backend_config == backend_config
+        assert config.session_timeout == 600.0
+        assert config.max_sessions == 50
+        assert config.stateless is True
+        assert config.cors_origins == ["http://localhost:3000"]
+        assert config.auth_enabled is True
+        assert config.auth_token == "secret-token"
+
+
+class TestUtilityFunctions:
+    """Test utility functions."""
+    
+    def test_generate_session_id(self):
+        """Test session ID generation."""
+        # Generate multiple IDs
+        ids = [generate_session_id() for _ in range(10)]
+        
+        # All should be unique
+        assert len(set(ids)) == 10
+        
+        # All should be valid UUIDs
+        for session_id in ids:
+            assert len(session_id) == 36  # UUID string length
+            assert session_id.count("-") == 4  # UUID format
+            
+    def test_validate_auth_token(self):
+        """Test auth token validation."""
+        # No auth required
+        assert validate_auth_token(None, None) is True
+        assert validate_auth_token("any-token", None) is True
+        
+        # Auth required, no token provided
+        assert validate_auth_token(None, "expected-token") is False
+        assert validate_auth_token("", "expected-token") is False
+        
+        # Auth required, wrong token
+        assert validate_auth_token("wrong-token", "expected-token") is False
+        
+        # Auth required, correct token
+        assert validate_auth_token("expected-token", "expected-token") is True

--- a/tests/proxy/test_utils.py
+++ b/tests/proxy/test_utils.py
@@ -7,14 +7,14 @@ from asyncmcp.proxy.utils import (
     generate_session_id,
     validate_auth_token,
 )
-from asyncmcp.sqs.utils import SqsClientConfig
 from asyncmcp.sns_sqs.utils import SnsSqsClientConfig
+from asyncmcp.sqs.utils import SqsClientConfig
 from asyncmcp.webhook.utils import WebhookClientConfig
 
 
 class TestProxyConfig:
     """Test ProxyConfig class."""
-    
+
     def test_default_config(self):
         """Test default configuration values."""
         config = ProxyConfig(
@@ -23,7 +23,7 @@ class TestProxyConfig:
                 response_queue_url="https://sqs.example.com/response",
             )
         )
-        
+
         assert config.host == "127.0.0.1"
         assert config.port == 8080
         assert config.server_path == "/mcp"
@@ -31,27 +31,27 @@ class TestProxyConfig:
         assert config.session_timeout == 300.0
         assert config.max_sessions == 100
         assert config.stateless is False
-        
+
     def test_config_validation(self):
         """Test configuration validation."""
         # Missing backend_config
         with pytest.raises(ValueError, match="backend_config is required"):
             ProxyConfig()
-            
+
         # Mismatched transport type and config
         with pytest.raises(ValueError, match="backend_config must be SqsClientConfig"):
             ProxyConfig(
                 backend_transport="sqs",
                 backend_config=WebhookClientConfig(server_url="http://example.com"),
             )
-            
+
     def test_custom_config(self):
         """Test custom configuration values."""
         backend_config = SnsSqsClientConfig(
             sns_topic_arn="arn:aws:sns:us-east-1:123:topic",
             sqs_queue_url="https://sqs.example.com/queue",
         )
-        
+
         config = ProxyConfig(
             host="0.0.0.0",
             port=9090,
@@ -65,7 +65,7 @@ class TestProxyConfig:
             auth_enabled=True,
             auth_token="secret-token",
         )
-        
+
         assert config.host == "0.0.0.0"
         assert config.port == 9090
         assert config.server_path == "/proxy"
@@ -81,32 +81,32 @@ class TestProxyConfig:
 
 class TestUtilityFunctions:
     """Test utility functions."""
-    
+
     def test_generate_session_id(self):
         """Test session ID generation."""
         # Generate multiple IDs
         ids = [generate_session_id() for _ in range(10)]
-        
+
         # All should be unique
         assert len(set(ids)) == 10
-        
+
         # All should be valid UUIDs
         for session_id in ids:
             assert len(session_id) == 36  # UUID string length
             assert session_id.count("-") == 4  # UUID format
-            
+
     def test_validate_auth_token(self):
         """Test auth token validation."""
         # No auth required
         assert validate_auth_token(None, None) is True
         assert validate_auth_token("any-token", None) is True
-        
+
         # Auth required, no token provided
         assert validate_auth_token(None, "expected-token") is False
         assert validate_auth_token("", "expected-token") is False
-        
+
         # Auth required, wrong token
         assert validate_auth_token("wrong-token", "expected-token") is False
-        
+
         # Auth required, correct token
         assert validate_auth_token("expected-token", "expected-token") is True


### PR DESCRIPTION
This pull request introduces new documentation and example scripts to improve developer onboarding and testing for the AsyncMCP project. The main additions are a comprehensive guidance file for Claude Code users and two interactive example clients for testing MCP proxy servers using the MCP SDK.

**Documentation improvements:**

* Added `CLAUDE.md` with a detailed project overview, development commands, architecture explanation, testing strategy, and configuration guidance for contributors and Claude Code users.

**New example clients for proxy server testing:**

* Added `examples/proxy_client_interactive.py`, an interactive command-line MCP client that connects to a proxy server via SSE, allows tool listing and invocation, and demonstrates error handling and session management.
* Added `examples/proxy_client_mcp.py`, a streamlined MCP client using the MCP SDK for establishing SSE connections, session initialization, tool listing, and interactive tool invocation via command-line commands.