### PR TITLE
Fix MCP spec link to current specification version

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,4 +88,4 @@ Apache License 2.0 - see [LICENSE](LICENSE) file for details.
 
 - **Documentation**: [asyncmcp.mintlify.app](https://asyncmcp.mintlify.app)
 - **GitHub**: [github.com/bh-rat/asyncmcp](https://github.com/bh-rat/asyncmcp)
-- **MCP Specification**: [spec.modelcontextprotocol.io](https://spec.modelcontextprotocol.io)
+- **MCP Specification**: [modelcontextprotocol.io/specification/2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25)

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -180,7 +180,7 @@ async def main():
 
 - **GitHub**: [github.com/bh-rat/asyncmcp](https://github.com/bh-rat/asyncmcp)
 - **Issues**: [Report bugs or request features](https://github.com/bh-rat/asyncmcp/issues)
-- **MCP Spec**: [modelcontextprotocol.io](https://modelcontextprotocol.io)
+- **MCP Spec**: [modelcontextprotocol.io/specification/2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25)
 
 ## License
 


### PR DESCRIPTION
Updates outdated MCP spec links to https://modelcontextprotocol.io/specification/2025-11-25 in README and docs.