### PR TITLE
Migrate SQS and SNS+SQS dynamic init handshake to MCP _meta field

### DIFF
--- a/docs/concepts/overview.mdx
+++ b/docs/concepts/overview.mdx
@@ -76,16 +76,18 @@ asyncmcp implements custom initialization protocols to establish async transport
 
 <Tabs>
   <Tab title="SQS">
-    The client includes its response queue URL in the initialize request:
+    The client includes its response queue URL in the initialize request's `_meta` field:
     ```json
     {
       "jsonrpc": "2.0",
       "method": "initialize",
       "params": {
-        "response_queue_url": "https://sqs.region.amazonaws.com/account/client-responses",
         "clientInfo": {
           "name": "example-client",
           "version": "1.0.0"
+        },
+        "_meta": {
+          "responseQueueUrl": "https://sqs.region.amazonaws.com/account/client-responses"
         }
       }
     }
@@ -94,16 +96,18 @@ asyncmcp implements custom initialization protocols to establish async transport
   </Tab>
   
   <Tab title="SNS+SQS">
-    The client provides its SNS topic ARN for response routing:
+    The client provides its SNS topic ARN for response routing in the initialize request's `_meta` field:
     ```json
     {
       "jsonrpc": "2.0",
       "method": "initialize",
       "params": {
-        "client_topic_arn": "arn:aws:sns:region:account:client-topic",
         "clientInfo": {
           "name": "example-client",
           "version": "1.0.0"
+        },
+        "_meta": {
+          "clientTopicArn": "arn:aws:sns:region:account:client-topic"
         }
       }
     }

--- a/docs/concepts/session-management.mdx
+++ b/docs/concepts/session-management.mdx
@@ -98,7 +98,7 @@ def generate_session_id() -> str:
     },
     "_meta": {
       "session_id": "mcp_20240315143022_a1b2c3d4",
-      "response_queue_url": "https://sqs.../client-queue"
+      "responseQueueUrl": "https://sqs.../client-queue"
     }
   }
 }
@@ -219,9 +219,10 @@ Each transport discovers client endpoints differently:
 <AccordionGroup>
   <Accordion title="SQS Transport">
     ```python
-    # Client provides response queue URL in initialize
-    def extract_response_endpoint(self, initialize_params: dict) -> str:
-        return initialize_params.get('response_queue_url')
+    # Client provides response queue URL in the initialize request's _meta field
+    def extract_response_endpoint(self, initialize_params: dict) -> str | None:
+        meta = initialize_params.get('_meta') or {}
+        return meta.get('responseQueueUrl')
     
     # Or use dynamic queue creation
     async def create_response_queue(self, session_id: str) -> str:

--- a/examples/README.md
+++ b/examples/README.md
@@ -110,7 +110,9 @@ The initialize request includes the client's response queue URL:
     "protocolVersion": "2024-11-05",
     "capabilities": {},
     "clientInfo": {"name": "test-client", "version": "1.0"},
-    "response_queue_url": "http://localhost:4566/000000000000/mcp-consumer"
+    "_meta": {
+      "responseQueueUrl": "http://localhost:4566/000000000000/mcp-consumer"
+    }
   }
 }
 ```

--- a/examples/dynamic_sqs_example.py
+++ b/examples/dynamic_sqs_example.py
@@ -86,7 +86,7 @@ async def run_server():
 
     print("🚀 Starting SQS server with dynamic queue support...")
     print(f"📡 Listening on: {SERVER_REQUEST_QUEUE}")
-    print("📝 Send initialize request with 'response_queue_url' parameter to start a session")
+    print("📝 Send initialize request with 'responseQueueUrl' in _meta field to start a session")
 
     async with session_manager.run():
         try:
@@ -160,7 +160,9 @@ async def run_client():
                     "protocolVersion": "2024-11-05",
                     "capabilities": {"roots": {"listChanged": False}, "sampling": {}},
                     "clientInfo": {"name": "dynamic-example-client", "version": "1.0.0"},
-                    "response_queue_url": CLIENT_RESPONSE_QUEUE,  # Tell server where to send responses
+                    "_meta": {
+                        "responseQueueUrl": CLIENT_RESPONSE_QUEUE,  # Tell server where to send responses
+                    }
                 },
             )
         )

--- a/examples/sns_sqs_dynamic_example.py
+++ b/examples/sns_sqs_dynamic_example.py
@@ -9,7 +9,7 @@ This example demonstrates:
 3. Dynamic session creation and management
 4. Multiple concurrent clients supported
 
-The client provides a 'client_topic_arn' parameter in the initialize request,
+The client provides a 'clientTopicArn' in the _meta field of the initialize request,
 and the server creates a dedicated session for each client.
 """
 
@@ -110,7 +110,7 @@ async def run_server():
 
     print("🚀 Starting SNS/SQS server with dynamic topic support...")
     print(f"📡 Listening on queue: {SERVER_REQUEST_QUEUE}")
-    print("📝 Send initialize request with 'client_topic_arn' parameter to start a session")
+    print("📝 Send initialize request with 'clientTopicArn' in _meta field to start a session")
 
     async with session_manager.run():
         try:
@@ -161,7 +161,9 @@ async def run_client():
                     "capabilities": {},
                     "clientInfo": {"name": "sns-sqs-test-client", "version": "1.0"},
                     # Client provides its own topic ARN for responses
-                    "client_topic_arn": CLIENT_TOPIC,
+                    "_meta": {
+                        "clientTopicArn": CLIENT_TOPIC,
+                    },
                 },
             )
         )

--- a/src/asyncmcp/sns_sqs/client.py
+++ b/src/asyncmcp/sns_sqs/client.py
@@ -49,14 +49,16 @@ class SnsSqsClientTransport(BaseClientTransport):
         return attrs
 
     async def _prepare_initialize_request(self, session_message: SessionMessage) -> str:
-        """Prepare initialize request with client_topic_arn in params."""
+        """Prepare initialize request with clientTopicArn in _meta field."""
         if not self._is_initialization_request(session_message.message):
             return session_message.message.model_dump_json(by_alias=True, exclude_none=True)
 
         message_dict = session_message.message.model_dump(by_alias=True, exclude_none=True)
         if "params" not in message_dict:
             message_dict["params"] = {}
-        message_dict["params"]["client_topic_arn"] = self.client_topic_arn
+        if "_meta" not in message_dict["params"]:
+            message_dict["params"]["_meta"] = {}
+        message_dict["params"]["_meta"]["clientTopicArn"] = self.client_topic_arn
         return json.dumps(message_dict)
 
     async def send_message(self, session_message: SessionMessage) -> None:

--- a/src/asyncmcp/sns_sqs/manager.py
+++ b/src/asyncmcp/sns_sqs/manager.py
@@ -9,7 +9,6 @@ from uuid import uuid4
 import anyio
 import anyio.lowlevel
 import anyio.to_thread
-import mcp.types as types
 from anyio.abc import TaskStatus
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from mcp.server.lowlevel.server import Server as MCPServer
@@ -29,7 +28,7 @@ from asyncmcp.common.utils import (
     validate_session_id,
 )
 from asyncmcp.sns_sqs.server import OutgoingMessageEvent, SnsSqsTransport
-from asyncmcp.sns_sqs.utils import SnsSqsServerConfig
+from asyncmcp.sns_sqs.utils import SnsSqsServerConfig, extract_client_topic_arn_from_meta
 
 logger = logging.getLogger(__name__)
 
@@ -259,14 +258,10 @@ class SnsSqsSessionManager:
             await transport.send_message(session_message)
             return
 
-        client_topic_arn = None
-        message_root = session_message.message.root
-        if isinstance(message_root, types.JSONRPCRequest) and message_root.params:
-            if isinstance(message_root.params, dict):
-                client_topic_arn = message_root.params.get("client_topic_arn")
+        client_topic_arn = extract_client_topic_arn_from_meta(session_message.message)
 
         if not client_topic_arn:
-            logger.error("Initialize request missing required 'client_topic_arn' parameter")
+            logger.error("Initialize request missing required 'clientTopicArn' in _meta field")
             await delete_sqs_message(self.sqs_client, self.config.sqs_queue_url, sqs_message["ReceiptHandle"])
             return
 

--- a/src/asyncmcp/sns_sqs/utils.py
+++ b/src/asyncmcp/sns_sqs/utils.py
@@ -6,6 +6,8 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
+from mcp import types
+
 logger = logging.getLogger(__name__)
 
 
@@ -47,3 +49,19 @@ class SnsSqsClientConfig:
             raise ValueError("sqs_queue_url is required for client configuration")
         if not self.sns_topic_arn:
             raise ValueError("sns_topic_arn is required for client configuration")
+
+
+def extract_client_topic_arn_from_meta(message: types.JSONRPCMessage) -> str | None:
+    """Extract client topic ARN from the _meta field of an MCP message."""
+    if not isinstance(message.root, types.JSONRPCRequest):
+        return None
+
+    params = message.root.params
+    if not isinstance(params, dict):
+        return None
+
+    meta = params.get("_meta")
+    if not isinstance(meta, dict):
+        return None
+
+    return meta.get("clientTopicArn")

--- a/src/asyncmcp/sqs/client.py
+++ b/src/asyncmcp/sqs/client.py
@@ -48,14 +48,16 @@ class SqsClientTransport(BaseClientTransport):
         return attrs
 
     async def _prepare_initialize_request(self, session_message: SessionMessage) -> str:
-        """Prepare initialize request with response_queue_url in params."""
+        """Prepare initialize request with responseQueueUrl in _meta field."""
         if not self._is_initialization_request(session_message.message):
             return session_message.message.model_dump_json(by_alias=True, exclude_none=True)
 
         message_dict = session_message.message.model_dump(by_alias=True, exclude_none=True)
         if "params" not in message_dict:
             message_dict["params"] = {}
-        message_dict["params"]["response_queue_url"] = self.config.response_queue_url
+        if "_meta" not in message_dict["params"]:
+            message_dict["params"]["_meta"] = {}
+        message_dict["params"]["_meta"]["responseQueueUrl"] = self.config.response_queue_url
         return json.dumps(message_dict)
 
     async def send_message(self, session_message: SessionMessage) -> None:

--- a/src/asyncmcp/sqs/manager.py
+++ b/src/asyncmcp/sqs/manager.py
@@ -9,7 +9,6 @@ from uuid import uuid4
 import anyio
 import anyio.lowlevel
 import anyio.to_thread
-import mcp.types as types
 from anyio.abc import TaskStatus
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from mcp import JSONRPCError
@@ -30,7 +29,7 @@ from asyncmcp.common.utils import (
     validate_session_id,
 )
 from asyncmcp.sqs.server import OutgoingMessageEvent, SqsTransport
-from asyncmcp.sqs.utils import SqsServerConfig
+from asyncmcp.sqs.utils import SqsServerConfig, extract_response_queue_url_from_meta
 
 logger = logging.getLogger(__name__)
 
@@ -235,14 +234,10 @@ class SqsSessionManager:
             await transport.send_message(session_message)
             return
 
-        response_queue_url = None
-        message_root = session_message.message.root
-        if isinstance(message_root, types.JSONRPCRequest) and message_root.params:
-            if isinstance(message_root.params, dict):
-                response_queue_url = message_root.params.get("response_queue_url")
+        response_queue_url = extract_response_queue_url_from_meta(session_message.message)
 
         if not response_queue_url:
-            logger.error("Initialize request missing required 'response_queue_url' parameter")
+            logger.error("Initialize request missing required 'responseQueueUrl' in _meta field")
             await delete_sqs_message(self.sqs_client, self.config.read_queue_url, sqs_message["ReceiptHandle"])
             return
 

--- a/src/asyncmcp/sqs/utils.py
+++ b/src/asyncmcp/sqs/utils.py
@@ -2,6 +2,8 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
+from mcp import types
+
 
 @dataclass
 class SqsServerConfig:
@@ -46,3 +48,19 @@ class SqsClientConfig:
         """Initialize client_id if not provided."""
         if self.client_id is None:
             self.client_id = str(uuid.uuid4())
+
+
+def extract_response_queue_url_from_meta(message: types.JSONRPCMessage) -> str | None:
+    """Extract response queue URL from the _meta field of an MCP message."""
+    if not isinstance(message.root, types.JSONRPCRequest):
+        return None
+
+    params = message.root.params
+    if not isinstance(params, dict):
+        return None
+
+    meta = params.get("_meta")
+    if not isinstance(meta, dict):
+        return None
+
+    return meta.get("responseQueueUrl")

--- a/tests/sns_sqs/test_integration.py
+++ b/tests/sns_sqs/test_integration.py
@@ -3,7 +3,8 @@ Integration tests for SNS/SQS transport functionality.
 """
 
 import json
-from unittest.mock import MagicMock
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import anyio
 import pytest
@@ -550,3 +551,161 @@ class TestSNSSQSValidationScenarios:
                 await anyio.sleep(0.2)
                 # Malformed message should be deleted after parsing failure
                 mock_sqs.delete_message.assert_called_once()
+
+
+def _make_init_sqs_message(
+    message_id: str,
+    receipt_handle: str,
+    client_id: str,
+    client_topic_arn: str | None,
+    request_id: int = 1,
+) -> dict:
+    """Build a fake SQS message carrying an MCP initialize request."""
+    params: dict = {
+        "protocolVersion": "2024-11-05",
+        "capabilities": {},
+        "clientInfo": {"name": client_id, "version": "1.0"},
+    }
+    if client_topic_arn is not None:
+        params["_meta"] = {"clientTopicArn": client_topic_arn}
+    return {
+        "MessageId": message_id,
+        "ReceiptHandle": receipt_handle,
+        "Body": json.dumps({"jsonrpc": "2.0", "id": request_id, "method": "initialize", "params": params}),
+        "MessageAttributes": {"Method": {"DataType": "String", "StringValue": "initialize"}},
+    }
+
+
+def _patched_transport_factory():
+    """Drop-in replacement for SnsSqsTransport that satisfies the manager's contract."""
+
+    def factory(*args, **kwargs):
+        transport = MagicMock()
+        transport.is_terminated = False
+        transport.client_topic_arn = kwargs.get("client_topic_arn")
+        transport.send_message = AsyncMock()
+        transport.send_to_client_topic = AsyncMock()
+        transport.send_error_to_client_topic = AsyncMock()
+
+        @asynccontextmanager
+        async def _connect():
+            yield (MagicMock(), MagicMock())
+
+        transport.connect = _connect
+        return transport
+
+    return factory
+
+
+class TestSnsSqsDynamicInitFlow:
+    """End-to-end tests for the dynamic initialize handshake using `_meta.clientTopicArn`."""
+
+    @pytest.mark.anyio
+    async def test_initialize_with_client_topic_arn_creates_session(self, server_config, mock_mcp_server):
+        """An initialize request with `clientTopicArn` in `_meta` constructs a transport for that topic."""
+        client_topic_arn = "arn:aws:sns:us-east-1:000000000000:client-1-topic"
+        mock_sqs = MagicMock()
+        mock_sns = MagicMock()
+        init_message = _make_init_sqs_message(
+            "init-1", "init-handle-1", "test-client", client_topic_arn=client_topic_arn
+        )
+
+        call_count = 0
+
+        def receive_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return {"Messages": [init_message]} if call_count == 1 else {"Messages": []}
+
+        mock_sqs.receive_message.side_effect = receive_side_effect
+        mock_sqs.delete_message.return_value = {}
+
+        with patch(
+            "asyncmcp.sns_sqs.manager.SnsSqsTransport", side_effect=_patched_transport_factory()
+        ) as mock_transport_cls:
+            session_manager = SnsSqsSessionManager(
+                app=mock_mcp_server, config=server_config, sqs_client=mock_sqs, sns_client=mock_sns
+            )
+
+            with anyio.move_on_after(0.5):
+                async with session_manager.run():
+                    await anyio.sleep(0.2)
+
+        assert mock_transport_cls.call_count == 1
+        assert mock_transport_cls.call_args.kwargs["client_topic_arn"] == client_topic_arn
+        assert mock_sqs.delete_message.called
+
+    @pytest.mark.anyio
+    async def test_initialize_missing_meta_skips_session_creation(self, server_config, mock_mcp_server):
+        """An initialize request without `_meta` is acked but does not create a session."""
+        mock_sqs = MagicMock()
+        mock_sns = MagicMock()
+        init_message = _make_init_sqs_message(
+            "bad-init-1", "bad-init-handle-1", "invalid-client", client_topic_arn=None
+        )
+
+        call_count = 0
+
+        def receive_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return {"Messages": [init_message]} if call_count == 1 else {"Messages": []}
+
+        mock_sqs.receive_message.side_effect = receive_side_effect
+        mock_sqs.delete_message.return_value = {}
+
+        with patch(
+            "asyncmcp.sns_sqs.manager.SnsSqsTransport", side_effect=_patched_transport_factory()
+        ) as mock_transport_cls:
+            session_manager = SnsSqsSessionManager(
+                app=mock_mcp_server, config=server_config, sqs_client=mock_sqs, sns_client=mock_sns
+            )
+
+            with anyio.move_on_after(0.5):
+                async with session_manager.run():
+                    await anyio.sleep(0.2)
+
+        mock_transport_cls.assert_not_called()
+        assert mock_sqs.delete_message.called
+        mock_sns.publish.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_multiple_clients_get_isolated_topic_arns(self, server_config, mock_mcp_server):
+        """Two distinct initialize requests yield two transports with their own client topic ARNs."""
+        client1_arn = "arn:aws:sns:us-east-1:000000000000:client-1-topic"
+        client2_arn = "arn:aws:sns:us-east-1:000000000000:client-2-topic"
+        mock_sqs = MagicMock()
+        mock_sns = MagicMock()
+        init1 = _make_init_sqs_message("init-1", "init-1-handle", "client-1", client_topic_arn=client1_arn)
+        init2 = _make_init_sqs_message(
+            "init-2", "init-2-handle", "client-2", client_topic_arn=client2_arn, request_id=2
+        )
+
+        call_count = 0
+
+        def receive_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return {"Messages": [init1]}
+            if call_count == 2:
+                return {"Messages": [init2]}
+            return {"Messages": []}
+
+        mock_sqs.receive_message.side_effect = receive_side_effect
+        mock_sqs.delete_message.return_value = {}
+
+        with patch(
+            "asyncmcp.sns_sqs.manager.SnsSqsTransport", side_effect=_patched_transport_factory()
+        ) as mock_transport_cls:
+            session_manager = SnsSqsSessionManager(
+                app=mock_mcp_server, config=server_config, sqs_client=mock_sqs, sns_client=mock_sns
+            )
+
+            with anyio.move_on_after(0.7):
+                async with session_manager.run():
+                    await anyio.sleep(0.3)
+
+        assert mock_transport_cls.call_count == 2
+        captured_arns = [call.kwargs["client_topic_arn"] for call in mock_transport_cls.call_args_list]
+        assert sorted(captured_arns) == sorted([client1_arn, client2_arn])

--- a/tests/sns_sqs/test_utils.py
+++ b/tests/sns_sqs/test_utils.py
@@ -1,0 +1,122 @@
+"""Tests for SNS/SQS utility functions."""
+
+import pytest
+from mcp.types import JSONRPCMessage, JSONRPCNotification, JSONRPCRequest, JSONRPCResponse
+
+from asyncmcp.sns_sqs.utils import (
+    SnsSqsClientConfig,
+    SnsSqsServerConfig,
+    extract_client_topic_arn_from_meta,
+)
+
+
+class TestSnsSqsServerConfig:
+    """Test SnsSqsServerConfig dataclass."""
+
+    def test_default_config(self):
+        config = SnsSqsServerConfig(sqs_queue_url="http://localhost:4566/000000000000/server-queue")
+
+        assert config.sqs_queue_url == "http://localhost:4566/000000000000/server-queue"
+        assert config.max_messages == 10
+        assert config.wait_time_seconds == 20
+        assert config.poll_interval_seconds == 5.0
+
+    def test_validation_requires_queue_url(self):
+        with pytest.raises(ValueError, match="sqs_queue_url is required"):
+            SnsSqsServerConfig(sqs_queue_url="")
+
+
+class TestSnsSqsClientConfig:
+    """Test SnsSqsClientConfig dataclass."""
+
+    def test_validation_requires_queue_url(self):
+        with pytest.raises(ValueError, match="sqs_queue_url is required"):
+            SnsSqsClientConfig(sqs_queue_url="", sns_topic_arn="arn:aws:sns:us-east-1:000000000000:topic")
+
+    def test_validation_requires_topic_arn(self):
+        with pytest.raises(ValueError, match="sns_topic_arn is required"):
+            SnsSqsClientConfig(sqs_queue_url="http://localhost:4566/000000000000/queue", sns_topic_arn="")
+
+
+@pytest.fixture
+def sample_jsonrpc_initialize_request():
+    """Initialize request carrying clientTopicArn in _meta."""
+    return JSONRPCMessage(
+        root=JSONRPCRequest(
+            jsonrpc="2.0",
+            id=1,
+            method="initialize",
+            params={
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "test-client", "version": "1.0"},
+                "_meta": {
+                    "clientTopicArn": "arn:aws:sns:us-east-1:000000000000:client-topic",
+                },
+            },
+        )
+    )
+
+
+class TestExtractClientTopicArnFromMeta:
+    """Test extract_client_topic_arn_from_meta helper."""
+
+    def test_valid(self, sample_jsonrpc_initialize_request):
+        arn = extract_client_topic_arn_from_meta(sample_jsonrpc_initialize_request)
+
+        assert arn == "arn:aws:sns:us-east-1:000000000000:client-topic"
+
+    def test_missing_meta(self, sample_jsonrpc_request):
+        arn = extract_client_topic_arn_from_meta(sample_jsonrpc_request)
+
+        assert arn is None
+
+    def test_meta_without_client_topic_arn(self):
+        message = JSONRPCMessage(
+            root=JSONRPCRequest(
+                jsonrpc="2.0",
+                id=1,
+                method="initialize",
+                params={"_meta": {"someOtherKey": "value"}},
+            )
+        )
+
+        assert extract_client_topic_arn_from_meta(message) is None
+
+    def test_meta_is_not_dict(self):
+        message = JSONRPCMessage(
+            root=JSONRPCRequest(
+                jsonrpc="2.0",
+                id=1,
+                method="initialize",
+                params={"_meta": "not-a-dict"},
+            )
+        )
+
+        assert extract_client_topic_arn_from_meta(message) is None
+
+    def test_no_params(self):
+        message = JSONRPCMessage(root=JSONRPCRequest(jsonrpc="2.0", id=1, method="test/method"))
+
+        assert extract_client_topic_arn_from_meta(message) is None
+
+    def test_notification_returns_none(self, sample_jsonrpc_notification):
+        arn = extract_client_topic_arn_from_meta(sample_jsonrpc_notification)
+
+        assert arn is None
+
+    def test_notification_with_meta_still_returns_none(self):
+        message = JSONRPCMessage(
+            root=JSONRPCNotification(
+                jsonrpc="2.0",
+                method="notifications/initialized",
+                params={"_meta": {"clientTopicArn": "arn:aws:sns:us-east-1:000000000000:topic"}},
+            )
+        )
+
+        assert extract_client_topic_arn_from_meta(message) is None
+
+    def test_response_returns_none(self):
+        message = JSONRPCMessage(root=JSONRPCResponse(jsonrpc="2.0", id=1, result={"ok": True}))
+
+        assert extract_client_topic_arn_from_meta(message) is None

--- a/tests/sqs/shared_fixtures.py
+++ b/tests/sqs/shared_fixtures.py
@@ -25,7 +25,7 @@ def sample_jsonrpc_request():
 
 @pytest.fixture
 def sample_jsonrpc_initialize_request():
-    """Sample JSON-RPC initialize request with response_queue_url."""
+    """Sample JSON-RPC initialize request with responseQueueUrl in _meta."""
     return JSONRPCMessage(
         root=JSONRPCRequest(
             jsonrpc="2.0",
@@ -35,7 +35,9 @@ def sample_jsonrpc_initialize_request():
                 "protocolVersion": "2024-11-05",
                 "capabilities": {},
                 "clientInfo": {"name": "test-client", "version": "1.0"},
-                "response_queue_url": "http://localhost:4566/000000000000/client-responses",
+                "_meta": {
+                    "responseQueueUrl": "http://localhost:4566/000000000000/client-responses",
+                },
             },
         )
     )
@@ -66,7 +68,7 @@ def sample_sqs_message():
 
 @pytest.fixture
 def sample_initialize_sqs_message():
-    """Sample SQS initialize message with response_queue_url."""
+    """Sample SQS initialize message with responseQueueUrl in _meta."""
     return {
         "MessageId": "init-msg-1",
         "ReceiptHandle": "init-handle-1",
@@ -79,7 +81,9 @@ def sample_initialize_sqs_message():
                     "protocolVersion": "2024-11-05",
                     "capabilities": {},
                     "clientInfo": {"name": "test-client", "version": "1.0"},
-                    "response_queue_url": "http://localhost:4566/000000000000/client-responses",
+                    "_meta": {
+                        "responseQueueUrl": "http://localhost:4566/000000000000/client-responses",
+                    },
                 },
             }
         ),

--- a/tests/sqs/test_client_transport.py
+++ b/tests/sqs/test_client_transport.py
@@ -63,15 +63,16 @@ class TestSqsClient:
                 # Verify send_message was called
                 assert mock_sqs_client.send_message.called
 
-                # Get the call arguments to verify response_queue_url was added
+                # Get the call arguments to verify responseQueueUrl was added in _meta
                 call_args = mock_sqs_client.send_message.call_args
                 message_body = call_args[1]["MessageBody"]
 
-                # Parse the message body and check it contains response_queue_url
+                # Parse the message body and check it contains responseQueueUrl in _meta
                 parsed_message = json.loads(message_body)
                 assert "params" in parsed_message
-                assert "response_queue_url" in parsed_message["params"]
-                assert parsed_message["params"]["response_queue_url"] == client_response_queue_url
+                assert "_meta" in parsed_message["params"]
+                assert "responseQueueUrl" in parsed_message["params"]["_meta"]
+                assert parsed_message["params"]["_meta"]["responseQueueUrl"] == client_response_queue_url
 
     @pytest.mark.anyio
     async def test_client_send_regular_request(
@@ -96,11 +97,11 @@ class TestSqsClient:
                 # Verify send_message was called
                 assert mock_sqs_client.send_message.called
 
-                # Regular requests should not have response_queue_url added
+                # Regular requests should not have responseQueueUrl added
                 call_args = mock_sqs_client.send_message.call_args
                 message_body = call_args[1]["MessageBody"]
                 parsed_message = json.loads(message_body)
-                # Should be the original message without response_queue_url added
+                # Should be the original message without responseQueueUrl added
                 assert parsed_message["method"] == "test/method"
 
     @pytest.mark.anyio

--- a/tests/sqs/test_integration.py
+++ b/tests/sqs/test_integration.py
@@ -48,7 +48,9 @@ class TestSQSIntegrationWithDynamicQueues:
                                         "protocolVersion": "2024-11-05",
                                         "capabilities": {},
                                         "clientInfo": {"name": "test-client", "version": "1.0"},
-                                        "response_queue_url": client_response_queue,
+                                        "_meta": {
+                                            "responseQueueUrl": client_response_queue,
+                                        },
                                     },
                                 }
                             ),
@@ -285,7 +287,9 @@ class TestSQSIntegrationWithDynamicQueues:
                             "protocolVersion": "2024-11-05",
                             "capabilities": {},
                             "clientInfo": {"name": "client-1", "version": "1.0"},
-                            "response_queue_url": client1_response_queue,
+                            "_meta": {
+                                "responseQueueUrl": client1_response_queue,
+                            },
                         },
                     }
                 ),
@@ -303,7 +307,9 @@ class TestSQSIntegrationWithDynamicQueues:
                             "protocolVersion": "2024-11-05",
                             "capabilities": {},
                             "clientInfo": {"name": "client-2", "version": "1.0"},
-                            "response_queue_url": client2_response_queue,
+                            "_meta": {
+                                "responseQueueUrl": client2_response_queue,
+                            },
                         },
                     }
                 ),
@@ -359,7 +365,7 @@ class TestSQSIntegrationWithDynamicQueues:
                         "protocolVersion": "2024-11-05",
                         "capabilities": {},
                         "clientInfo": {"name": "invalid-client", "version": "1.0"},
-                        # Missing response_queue_url
+                        # Missing responseQueueUrl in _meta
                     },
                 }
             ),
@@ -378,7 +384,7 @@ class TestSQSIntegrationWithDynamicQueues:
             async with session_manager.run():
                 await anyio.sleep(0.2)  # Let it process the invalid message
 
-                # Session should not be created due to missing response_queue_url
+                # Session should not be created due to missing responseQueueUrl
                 stats = session_manager.get_all_sessions()
                 # The invalid message should be handled gracefully without creating a session
 
@@ -404,7 +410,9 @@ class TestSQSIntegrationWithDynamicQueues:
                         "protocolVersion": "2024-11-05",
                         "capabilities": {},
                         "clientInfo": {"name": "cleanup-client", "version": "1.0"},
-                        "response_queue_url": "http://localhost:4566/000000000000/cleanup-responses",
+                        "_meta": {
+                            "responseQueueUrl": "http://localhost:4566/000000000000/cleanup-responses",
+                        },
                     },
                 }
             ),
@@ -615,7 +623,9 @@ class TestSQSValidationScenarios:
                         "protocolVersion": "2024-11-05",
                         "capabilities": {},
                         "clientInfo": {"name": "test-client", "version": "1.0"},
-                        "response_queue_url": "http://localhost:4566/000000000000/responses",
+                        "_meta": {
+                            "responseQueueUrl": "http://localhost:4566/000000000000/responses",
+                        },
                     },
                 }
             ),

--- a/tests/sqs/test_utils.py
+++ b/tests/sqs/test_utils.py
@@ -1,0 +1,108 @@
+"""Tests for SQS utility functions."""
+
+from mcp.types import JSONRPCMessage, JSONRPCNotification, JSONRPCRequest, JSONRPCResponse
+
+from asyncmcp.sqs.utils import (
+    SqsClientConfig,
+    SqsServerConfig,
+    extract_response_queue_url_from_meta,
+)
+
+
+class TestSqsServerConfig:
+    """Test SqsServerConfig dataclass."""
+
+    def test_default_config(self):
+        config = SqsServerConfig(read_queue_url="http://localhost:4566/000000000000/server-requests")
+
+        assert config.read_queue_url == "http://localhost:4566/000000000000/server-requests"
+        assert config.max_messages == 10
+        assert config.wait_time_seconds == 20
+        assert config.poll_interval_seconds == 5.0
+        assert config.transport_timeout_seconds is None
+
+
+class TestSqsClientConfig:
+    """Test SqsClientConfig dataclass."""
+
+    def test_client_id_auto_generated_when_omitted(self):
+        config = SqsClientConfig(
+            read_queue_url="http://localhost:4566/000000000000/server-requests",
+            response_queue_url="http://localhost:4566/000000000000/client-responses",
+        )
+
+        assert config.client_id is not None
+        assert isinstance(config.client_id, str)
+
+    def test_client_id_preserved_when_provided(self):
+        config = SqsClientConfig(
+            read_queue_url="http://localhost:4566/000000000000/server-requests",
+            response_queue_url="http://localhost:4566/000000000000/client-responses",
+            client_id="explicit-client",
+        )
+
+        assert config.client_id == "explicit-client"
+
+
+class TestExtractResponseQueueUrlFromMeta:
+    """Test extract_response_queue_url_from_meta helper."""
+
+    def test_valid(self, sample_jsonrpc_initialize_request):
+        url = extract_response_queue_url_from_meta(sample_jsonrpc_initialize_request)
+
+        assert url == "http://localhost:4566/000000000000/client-responses"
+
+    def test_missing_meta(self, sample_jsonrpc_request):
+        url = extract_response_queue_url_from_meta(sample_jsonrpc_request)
+
+        assert url is None
+
+    def test_meta_without_response_queue_url(self):
+        message = JSONRPCMessage(
+            root=JSONRPCRequest(
+                jsonrpc="2.0",
+                id=1,
+                method="initialize",
+                params={"_meta": {"someOtherKey": "value"}},
+            )
+        )
+
+        assert extract_response_queue_url_from_meta(message) is None
+
+    def test_meta_is_not_dict(self):
+        message = JSONRPCMessage(
+            root=JSONRPCRequest(
+                jsonrpc="2.0",
+                id=1,
+                method="initialize",
+                params={"_meta": "not-a-dict"},
+            )
+        )
+
+        assert extract_response_queue_url_from_meta(message) is None
+
+    def test_no_params(self):
+        message = JSONRPCMessage(root=JSONRPCRequest(jsonrpc="2.0", id=1, method="test/method"))
+
+        assert extract_response_queue_url_from_meta(message) is None
+
+    def test_notification_returns_none(self, sample_jsonrpc_notification):
+        url = extract_response_queue_url_from_meta(sample_jsonrpc_notification)
+
+        assert url is None
+
+    def test_notification_with_meta_still_returns_none(self):
+        message = JSONRPCMessage(
+            root=JSONRPCNotification(
+                jsonrpc="2.0",
+                method="notifications/initialized",
+                params={"_meta": {"responseQueueUrl": "http://example.com/queue"}},
+            )
+        )
+
+        assert extract_response_queue_url_from_meta(message) is None
+
+    def test_response_returns_none(self):
+        message = JSONRPCMessage(root=JSONRPCResponse(jsonrpc="2.0", id=1, result={"ok": True}))
+
+        assert extract_response_queue_url_from_meta(message) is None


### PR DESCRIPTION
## Summary
- Move `responseQueueUrl` (SQS) and `clientTopicArn` (SNS+SQS) from custom top-level `params` keys into the spec-blessed `params._meta` field on the initialize request, matching the existing webhook transport pattern.
- Add helper `extract_response_queue_url_from_meta` / `extract_client_topic_arn_from_meta` in each transport's `utils.py`; managers now read from `_meta` via these helpers.
- Update examples and the documentation pages that show the wire-format JSON. Python config kwargs (`SqsClientConfig(response_queue_url=...)`, etc.) are unchanged.
- Wire format is a hard break (no backward compat). Older clients will need to upgrade; project is in alpha.

## Tests
- New `tests/sqs/test_utils.py` and `tests/sns_sqs/test_utils.py` cover the helpers (valid, missing `_meta`, missing key, non-dict `_meta`, no params, notification, response).
- New `TestSnsSqsDynamicInitFlow` class in `tests/sns_sqs/test_integration.py` covers the previously-untested SNS+SQS dynamic-init path: happy path, missing-`_meta` rejection, multi-client topic-ARN isolation.
- Updated existing `tests/sqs/` fixtures and assertions to the new `_meta` shape.

## Test plan
- [x] `uv run pytest tests/sqs tests/sns_sqs tests/webhook tests/proxy tests/common tests/streamable_http_webhook` — 259 passed, 25 skipped
- [x] `uv run ruff check src/ tests/`
- [x] `uv run ruff format --check src/ tests/`